### PR TITLE
Added support for raw_body in response

### DIFF
--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -141,10 +141,13 @@ pub trait DeliverableRequest<'a>: Sized + 'a {
             return Err(PrimaBridgeError::WrongStatusCode(url, status_code));
         }
         let response_headers = response.headers().clone();
-        let response_body = response.text().map_err(|e| PrimaBridgeError::HttpError {
-            source: e,
-            url: url.clone(),
-        })?;
+        let response_body = response
+            .bytes()
+            .map_err(|e| PrimaBridgeError::HttpError {
+                source: e,
+                url: url.clone(),
+            })?
+            .to_vec();
 
         match self.get_request_type() {
             RequestType::Rest => Ok(Response::rest(
@@ -203,12 +206,13 @@ pub trait DeliverableRequest<'a>: Sized + 'a {
         let response_headers = response.headers().clone();
 
         let response_body = response
-            .text()
+            .bytes()
             .map_err(|e| PrimaBridgeError::HttpError {
                 source: e,
                 url: url.clone(),
             })
-            .await?;
+            .await?
+            .to_vec();
 
         match self.get_request_type() {
             RequestType::Rest => Ok(Response::rest(

--- a/src/response.rs
+++ b/src/response.rs
@@ -17,7 +17,7 @@ enum RequestType {
 #[derive(Debug)]
 pub struct Response {
     url: Url,
-    response_body: String,
+    response_body: Vec<u8>,
     status_code: StatusCode,
     response_headers: HeaderMap,
     request_id: Uuid,
@@ -28,7 +28,7 @@ impl Response {
     #[doc(hidden)]
     pub fn rest(
         url: Url,
-        response_body: String,
+        response_body: Vec<u8>,
         status_code: StatusCode,
         response_headers: HeaderMap,
         request_id: Uuid,
@@ -46,7 +46,7 @@ impl Response {
     #[doc(hidden)]
     pub fn graphql(
         url: Url,
-        response_body: String,
+        response_body: Vec<u8>,
         status_code: StatusCode,
         response_headers: HeaderMap,
         request_id: Uuid,
@@ -76,7 +76,7 @@ impl Response {
     where
         for<'de> T: Deserialize<'de> + Debug,
     {
-        let json_value = serde_json::from_str(self.response_body.as_str()).map_err(|e| {
+        let json_value = serde_json::from_slice(&self.response_body[..]).map_err(|e| {
             PrimaBridgeError::ResponseBodyNotDeserializable {
                 status_code: self.status_code,
                 source: e,
@@ -87,6 +87,10 @@ impl Response {
             selectors.insert(0, "data");
         };
         Ok(extract_inner_json(self.url, selectors, json_value)?)
+    }
+
+    pub fn raw_body(&self) -> &Vec<u8> {
+        &self.response_body
     }
 
     /// returns `true` if the response is successful

--- a/tests/async_bridge/rest.rs
+++ b/tests/async_bridge/rest.rs
@@ -124,3 +124,19 @@ async fn request_with_custom_headers() -> Result<(), Box<dyn Error>> {
     assert!(result.is_ok());
     Ok(())
 }
+
+#[tokio::test]
+async fn request_with_binary_body_response() -> Result<(), Box<dyn Error>> {
+    let body = b"abcde";
+
+    let (_m, bridge) = create_bridge_with_binary_body_matcher(body);
+
+    let result = RestRequest::new(&bridge)
+        .raw_body(body.to_vec())
+        .send()
+        .await?;
+    assert!(result.is_ok());
+
+    assert_eq!(body, &result.raw_body()[..]);
+    Ok(())
+}

--- a/tests/blocking/rest.rs
+++ b/tests/blocking/rest.rs
@@ -284,3 +284,15 @@ fn request_with_query_string_by_calling_once() -> Result<(), Box<dyn Error>> {
     assert!(result.is_ok());
     Ok(())
 }
+
+#[test]
+fn request_with_binary_raw_body() -> Result<(), Box<dyn Error>> {
+    let body = b"abcde";
+    let (_m, bridge) = create_bridge_with_binary_body_matcher(body);
+    let result = RestRequest::new(&bridge).raw_body(body.to_vec()).send()?;
+    assert!(result.is_ok());
+
+    assert_eq!(body, &result.raw_body()[..]);
+
+    Ok(())
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use mockito::{mock, Matcher, Mock};
+use mockito::{mock, BinaryBody, Matcher, Mock};
 use prima_bridge::prelude::*;
 use reqwest::Url;
 
@@ -119,6 +119,25 @@ pub fn create_bridge_with_json_body_matcher(json: serde_json::Value) -> (Mock, B
         )
         .match_body(Matcher::Json(json))
         .with_status(200)
+        .create();
+
+    let url = Url::parse(mockito::server_url().as_str()).unwrap();
+    let bridge = Bridge::new(url);
+
+    (mock, bridge)
+}
+
+pub fn create_bridge_with_binary_body_matcher(body: &[u8]) -> (Mock, Bridge) {
+    let mock = mock("GET", "/")
+        .match_header(
+            "x-request-id",
+            Matcher::Regex(
+                r"\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b".to_string(),
+            ),
+        )
+        .match_body(Matcher::Binary(BinaryBody::from_bytes(body.to_vec())))
+        .with_status(200)
+        .with_body(body)
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();


### PR DESCRIPTION
This PR adds the support for raw body in Response.

The `response_body` has been changed to `Vec<u8>` and exposed in the method `Response#raw_body`

The `get_data` has been changed with `serde_json::from_slice` instead of `serde_json::from_str`