### PR TITLE
Opentelemetry 0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 /target
 Cargo.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-### 0.6.1
+### Unreleased
+#####breaking change
+- opentelemetry updated to version 0.12. **Careful!!!** The opentelemetry version in your project should match the one in this library
+- several dependencies updated    
 #####bugfix
 - tokio and tokio-test are now dev-dependencies
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,18 @@ tracing_opentelemetry = ["opentelemetry", "tracing", "tracing-opentelemetry"]
 
 [dependencies]
 reqwest = { version = "0.11.0", features = ["json", "blocking"], optional = true }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
-thiserror = "1.0.20"
+serde = { version = "1.0.123", features = ["derive"] }
+serde_json = "1.0.61"
+thiserror = "1.0.23"
 uuid = { version = ">=0.7.0, <0.9.0", features = ["serde", "v4"] }
-futures = { version = "0.3.5", optional = true }
-futures-util = { version = "0.3.5", optional = true }
-opentelemetry = { version = ">=0.11.0, <0.12.0", optional = true }
-tracing = { version = "0.1.19", optional = true }
-tracing-opentelemetry = { version = "0.10.0", optional = true }
-async-trait = "0.1.41"
+futures = { version = "0.3.12", optional = true }
+futures-util = { version = "0.3.12", optional = true }
+opentelemetry = { version = ">=0.12.0, <0.13.0", optional = true }
+tracing = { version = "0.1.23", optional = true }
+tracing-opentelemetry = { version = "0.11.0", optional = true }
+async-trait = "0.1.42"
 
 [dev-dependencies]
-mockito = "^0.28"
+mockito = "^0.29"
 tokio = { version = "1.0.2", features = ["macros"] }
 tokio-test = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tracing_opentelemetry = ["opentelemetry", "tracing", "tracing-opentelemetry"]
 [dependencies]
 reqwest = { version = "0.11.0", features = ["json", "blocking"], optional = true }
 serde = { version = "1.0.123", features = ["derive"] }
-serde_json = "1.0.61"
+serde_json = "1.0.62"
 thiserror = "1.0.23"
 uuid = { version = ">=0.7.0, <0.9.0", features = ["serde", "v4"] }
 futures = { version = "0.3.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ async = ["reqwest", "futures", "futures-util"]
 tracing_opentelemetry = ["opentelemetry", "tracing", "tracing-opentelemetry"]
 
 [dependencies]
-reqwest = { version = "0.11.0", features = ["json", "blocking"], optional = true }
+reqwest = { version = "0.11.1", features = ["json", "blocking"], optional = true }
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
-thiserror = "1.0.23"
+thiserror = "1.0.24"
 uuid = { version = ">=0.7.0, <0.9.0", features = ["serde", "v4"] }
-futures = { version = "0.3.12", optional = true }
-futures-util = { version = "0.3.12", optional = true }
+futures = { version = "0.3.13", optional = true }
+futures-util = { version = "0.3.13", optional = true }
 opentelemetry = { version = ">=0.12.0, <0.13.0", optional = true }
-tracing = { version = "0.1.23", optional = true }
+tracing = { version = "0.1.25", optional = true }
 tracing-opentelemetry = { version = "0.11.0", optional = true }
 async-trait = "0.1.42"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.49.0
+FROM rust:1.50.0
 
 WORKDIR /code
 


### PR DESCRIPTION
In preparation of a version bump, this PR update:
- [BREAKING] opentelemetry to 0.12
- [BREAKING] tracing-opentelemetry to 0.11
- Other minor deps bump