### PR TITLE
builder pattern for the bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Next
+- deprecated the `new` and `with_user_agent` methods in favor of a builder
 - opentelemetry updated to version 0.16. **Careful!!!** The opentelemetry version in your project should match the one in this library
 - several dependencies updated
 - docker file based on Rust 1.54

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,68 @@
+use crate::Bridge;
+use reqwest::Url;
+
+#[cfg(feature = "blocking")]
+pub struct BridgeBuilder {
+    client_builder: reqwest::blocking::ClientBuilder,
+    endpoint: Url,
+}
+
+#[cfg(feature = "blocking")]
+impl BridgeBuilder {
+    pub fn create(endpoint: Url) -> Self {
+        Self {
+            endpoint,
+            client_builder: reqwest::blocking::ClientBuilder::new(),
+        }
+    }
+
+    pub fn with_user_agent(self, user_agent: impl Into<String>) -> Self {
+        Self {
+            client_builder: self.client_builder.user_agent(user_agent.into().as_str()),
+            ..self
+        }
+    }
+
+    pub fn build(self) -> Bridge {
+        Bridge {
+            client: self
+                .client_builder
+                .build()
+                .expect("Unable to create Bridge"),
+            endpoint: self.endpoint,
+        }
+    }
+}
+
+#[cfg(not(feature = "blocking"))]
+pub struct BridgeBuilder {
+    client_builder: reqwest::ClientBuilder,
+    endpoint: Url,
+}
+
+#[cfg(not(feature = "blocking"))]
+impl BridgeBuilder {
+    pub fn create(endpoint: Url) -> Self {
+        Self {
+            endpoint,
+            client_builder: reqwest::ClientBuilder::new(),
+        }
+    }
+
+    pub fn with_user_agent(self, user_agent: impl Into<String>) -> Self {
+        Self {
+            client_builder: self.client_builder.user_agent(user_agent.into().as_str()),
+            ..self
+        }
+    }
+
+    pub fn build(self) -> Bridge {
+        Bridge {
+            client: self
+                .client_builder
+                .build()
+                .expect("Unable to create Bridge"),
+            endpoint: self.endpoint,
+        }
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9,7 +9,7 @@ pub struct BridgeBuilder {
 
 #[cfg(feature = "blocking")]
 impl BridgeBuilder {
-    pub fn create(endpoint: Url) -> Self {
+    pub(crate) fn create(endpoint: Url) -> Self {
         Self {
             endpoint,
             client_builder: reqwest::blocking::ClientBuilder::new(),
@@ -42,7 +42,7 @@ pub struct BridgeBuilder {
 
 #[cfg(not(feature = "blocking"))]
 impl BridgeBuilder {
-    pub fn create(endpoint: Url) -> Self {
+    pub(crate) fn create(endpoint: Url) -> Self {
         Self {
             endpoint,
             client_builder: reqwest::ClientBuilder::new(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -21,7 +21,6 @@ impl BridgeBuilder {
     pub fn with_user_agent(self, user_agent: impl Into<String>) -> Self {
         Self {
             client_builder: self.client_builder.user_agent(user_agent.into().as_str()),
-            ..self
         }
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,50 +1,19 @@
 use crate::Bridge;
 use reqwest::Url;
 
-#[cfg(feature = "blocking")]
 pub struct BridgeBuilder {
+    #[cfg(feature = "blocking")]
     client_builder: reqwest::blocking::ClientBuilder,
-    endpoint: Url,
-}
-
-#[cfg(feature = "blocking")]
-impl BridgeBuilder {
-    pub(crate) fn create(endpoint: Url) -> Self {
-        Self {
-            endpoint,
-            client_builder: reqwest::blocking::ClientBuilder::new(),
-        }
-    }
-
-    pub fn with_user_agent(self, user_agent: impl Into<String>) -> Self {
-        Self {
-            client_builder: self.client_builder.user_agent(user_agent.into().as_str()),
-            ..self
-        }
-    }
-
-    pub fn build(self) -> Bridge {
-        Bridge {
-            client: self
-                .client_builder
-                .build()
-                .expect("Unable to create Bridge"),
-            endpoint: self.endpoint,
-        }
-    }
-}
-
-#[cfg(not(feature = "blocking"))]
-pub struct BridgeBuilder {
+    #[cfg(not(feature = "blocking"))]
     client_builder: reqwest::ClientBuilder,
-    endpoint: Url,
 }
 
-#[cfg(not(feature = "blocking"))]
 impl BridgeBuilder {
-    pub(crate) fn create(endpoint: Url) -> Self {
+    pub(crate) fn create() -> Self {
         Self {
-            endpoint,
+            #[cfg(feature = "blocking")]
+            client_builder: reqwest::blocking::ClientBuilder::new(),
+            #[cfg(not(feature = "blocking"))]
             client_builder: reqwest::ClientBuilder::new(),
         }
     }
@@ -56,13 +25,13 @@ impl BridgeBuilder {
         }
     }
 
-    pub fn build(self) -> Bridge {
+    pub fn build(self, endpoint: Url) -> Bridge {
         Bridge {
             client: self
                 .client_builder
                 .build()
                 .expect("Unable to create Bridge"),
-            endpoint: self.endpoint,
+            endpoint,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,11 @@ pub struct Bridge {
 }
 
 impl Bridge {
+    /// create an instance of [BridgeBuilder]
+    pub fn builder(endpoint: Url) -> BridgeBuilder {
+        BridgeBuilder::create(endpoint)
+    }
+
     #[deprecated(
         since = "0.8.0",
         note = "please use the .create() and .build() methods on the BridgeBuilder"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ pub struct Bridge {
 
 impl Bridge {
     /// create an instance of [BridgeBuilder]
-    pub fn builder(endpoint: Url) -> BridgeBuilder {
-        BridgeBuilder::create(endpoint)
+    pub fn builder() -> BridgeBuilder {
+        BridgeBuilder::create()
     }
 
     #[deprecated(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,13 @@
 use reqwest::Url;
 
 pub use self::{
+    builder::BridgeBuilder,
     request::{GraphQLRequest, Request},
     response::graphql::{Error, ParsedGraphqlResponse, PossiblyParsedData},
     response::Response,
 };
 
+mod builder;
 mod errors;
 pub mod prelude;
 mod request;
@@ -40,6 +42,10 @@ pub struct Bridge {
 }
 
 impl Bridge {
+    #[deprecated(
+        since = "0.8.0",
+        note = "please use the .create() and .build() methods on the BridgeBuilder"
+    )]
     pub fn new(endpoint: Url) -> Self {
         Self {
             #[cfg(feature = "blocking")]
@@ -50,6 +56,10 @@ impl Bridge {
         }
     }
 
+    #[deprecated(
+        since = "0.8.0",
+        note = "please use the .create() and .build() methods on the BridgeBuilder"
+    )]
     pub fn with_user_agent(endpoint: Url, user_agent: &str) -> Self {
         Self {
             #[cfg(feature = "blocking")]

--- a/tests/async_bridge/graphql.rs
+++ b/tests/async_bridge/graphql.rs
@@ -154,7 +154,7 @@ fn create_gql_bridge(status_code: usize, query: &str, body: &str) -> (Mock, Brid
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder(url).build();
+    let bridge = Bridge::builder().build(url);
 
     (mock, bridge)
 }

--- a/tests/async_bridge/graphql.rs
+++ b/tests/async_bridge/graphql.rs
@@ -7,7 +7,6 @@ use serde::Deserialize;
 use serde_json::json;
 
 use prima_bridge::prelude::*;
-//use prima_bridge::Request;
 use reqwest::header::{HeaderName, HeaderValue};
 use std::fs;
 

--- a/tests/async_bridge/graphql.rs
+++ b/tests/async_bridge/graphql.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde_json::json;
 
 use prima_bridge::prelude::*;
-use prima_bridge::Request;
+use prima_bridge::{BridgeBuilder, Request};
 use reqwest::header::{HeaderName, HeaderValue};
 use std::fs;
 
@@ -154,7 +154,7 @@ fn create_gql_bridge(status_code: usize, query: &str, body: &str) -> (Mock, Brid
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::new(url);
+    let bridge = BridgeBuilder::create(url).build();
 
     (mock, bridge)
 }

--- a/tests/async_bridge/graphql.rs
+++ b/tests/async_bridge/graphql.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde_json::json;
 
 use prima_bridge::prelude::*;
-use prima_bridge::{BridgeBuilder, Request};
+//use prima_bridge::Request;
 use reqwest::header::{HeaderName, HeaderValue};
 use std::fs;
 
@@ -154,7 +154,7 @@ fn create_gql_bridge(status_code: usize, query: &str, body: &str) -> (Mock, Brid
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url).build();
+    let bridge = Bridge::builder(url).build();
 
     (mock, bridge)
 }

--- a/tests/async_bridge/rest.rs
+++ b/tests/async_bridge/rest.rs
@@ -1,6 +1,5 @@
 use crate::common::*;
 use prima_bridge::prelude::*;
-use prima_bridge::BridgeBuilder;
 use reqwest::header::{HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -188,7 +187,7 @@ async fn gzip_compression() -> Result<(), Box<dyn Error>> {
         .with_body(body)
         .create();
 
-    let bridge = BridgeBuilder::create(mockito::server_url().parse().unwrap()).build();
+    let bridge = Bridge::builder(mockito::server_url().parse().unwrap()).build();
 
     let result: String = RestRequest::new(&bridge)
         .send()

--- a/tests/async_bridge/rest.rs
+++ b/tests/async_bridge/rest.rs
@@ -187,7 +187,7 @@ async fn gzip_compression() -> Result<(), Box<dyn Error>> {
         .with_body(body)
         .create();
 
-    let bridge = Bridge::builder(mockito::server_url().parse().unwrap()).build();
+    let bridge = Bridge::builder().build(mockito::server_url().parse().unwrap());
 
     let result: String = RestRequest::new(&bridge)
         .send()

--- a/tests/async_bridge/rest.rs
+++ b/tests/async_bridge/rest.rs
@@ -1,5 +1,6 @@
 use crate::common::*;
 use prima_bridge::prelude::*;
+use prima_bridge::BridgeBuilder;
 use reqwest::header::{HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -187,7 +188,7 @@ async fn gzip_compression() -> Result<(), Box<dyn Error>> {
         .with_body(body)
         .create();
 
-    let bridge = Bridge::new(mockito::server_url().parse().unwrap());
+    let bridge = BridgeBuilder::create(mockito::server_url().parse().unwrap()).build();
 
     let result: String = RestRequest::new(&bridge)
         .send()

--- a/tests/blocking/graphql.rs
+++ b/tests/blocking/graphql.rs
@@ -102,12 +102,12 @@ fn create_gql_bridge(status_code: usize, query: &str, body: &str) -> (Mock, Brid
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder(url).build();
+    let bridge = Bridge::builder().build(url);
 
     (mock, bridge)
 }
 
 fn mock_bridge() -> Bridge {
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    Bridge::builder(url).build()
+    Bridge::builder().build(url)
 }

--- a/tests/blocking/graphql.rs
+++ b/tests/blocking/graphql.rs
@@ -7,7 +7,6 @@ use serde::Deserialize;
 use serde_json::json;
 
 use prima_bridge::prelude::*;
-use prima_bridge::BridgeBuilder;
 use reqwest::header::{HeaderName, HeaderValue};
 
 #[derive(Deserialize, Clone, Debug, PartialEq)]
@@ -103,12 +102,12 @@ fn create_gql_bridge(status_code: usize, query: &str, body: &str) -> (Mock, Brid
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url).build();
+    let bridge = Bridge::builder(url).build();
 
     (mock, bridge)
 }
 
 fn mock_bridge() -> Bridge {
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    BridgeBuilder::create(url).build()
+    Bridge::builder(url).build()
 }

--- a/tests/blocking/graphql.rs
+++ b/tests/blocking/graphql.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use serde_json::json;
 
 use prima_bridge::prelude::*;
+use prima_bridge::BridgeBuilder;
 use reqwest::header::{HeaderName, HeaderValue};
 
 #[derive(Deserialize, Clone, Debug, PartialEq)]
@@ -102,12 +103,12 @@ fn create_gql_bridge(status_code: usize, query: &str, body: &str) -> (Mock, Brid
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::new(url);
+    let bridge = BridgeBuilder::create(url).build();
 
     (mock, bridge)
 }
 
 fn mock_bridge() -> Bridge {
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    Bridge::new(url)
+    BridgeBuilder::create(url).build()
 }

--- a/tests/blocking/rest.rs
+++ b/tests/blocking/rest.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use prima_bridge::prelude::*;
 
 use crate::common::*;
-use prima_bridge::{BridgeBuilder, Request};
+use prima_bridge::Request;
 use reqwest::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use reqwest::Url;
 
@@ -205,7 +205,7 @@ fn request_post_with_custom_raw_body() -> Result<(), Box<dyn Error>> {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url).build();
+    let bridge = Bridge::builder(url).build();
 
     let result = Request::post(&bridge).raw_body(body).send();
     assert!(result.is_ok());
@@ -264,7 +264,7 @@ fn request_with_query_string() -> Result<(), Box<dyn Error>> {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url).build();
+    let bridge = Bridge::builder(url).build();
 
     let result = Request::get(&bridge)
         .with_query_pair("hello", "world!")
@@ -285,7 +285,7 @@ fn request_with_query_string_by_calling_once() -> Result<(), Box<dyn Error>> {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url).build();
+    let bridge = Bridge::builder(url).build();
 
     let result = Request::get(&bridge)
         .with_query_pairs(vec![("hello", "world!"), ("prima", "bridge")])

--- a/tests/blocking/rest.rs
+++ b/tests/blocking/rest.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use prima_bridge::prelude::*;
 
 use crate::common::*;
-use prima_bridge::Request;
+use prima_bridge::{BridgeBuilder, Request};
 use reqwest::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use reqwest::Url;
 
@@ -205,7 +205,7 @@ fn request_post_with_custom_raw_body() -> Result<(), Box<dyn Error>> {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::new(url);
+    let bridge = BridgeBuilder::create(url).build();
 
     let result = Request::post(&bridge).raw_body(body).send();
     assert!(result.is_ok());
@@ -264,7 +264,7 @@ fn request_with_query_string() -> Result<(), Box<dyn Error>> {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::new(url);
+    let bridge = BridgeBuilder::create(url).build();
 
     let result = Request::get(&bridge)
         .with_query_pair("hello", "world!")
@@ -285,7 +285,7 @@ fn request_with_query_string_by_calling_once() -> Result<(), Box<dyn Error>> {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::new(url);
+    let bridge = BridgeBuilder::create(url).build();
 
     let result = Request::get(&bridge)
         .with_query_pairs(vec![("hello", "world!"), ("prima", "bridge")])

--- a/tests/blocking/rest.rs
+++ b/tests/blocking/rest.rs
@@ -205,7 +205,7 @@ fn request_post_with_custom_raw_body() -> Result<(), Box<dyn Error>> {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder(url).build();
+    let bridge = Bridge::builder().build(url);
 
     let result = Request::post(&bridge).raw_body(body).send();
     assert!(result.is_ok());
@@ -264,7 +264,7 @@ fn request_with_query_string() -> Result<(), Box<dyn Error>> {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder(url).build();
+    let bridge = Bridge::builder().build(url);
 
     let result = Request::get(&bridge)
         .with_query_pair("hello", "world!")
@@ -285,7 +285,7 @@ fn request_with_query_string_by_calling_once() -> Result<(), Box<dyn Error>> {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder(url).build();
+    let bridge = Bridge::builder().build(url);
 
     let result = Request::get(&bridge)
         .with_query_pairs(vec![("hello", "world!"), ("prima", "bridge")])

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -26,7 +26,7 @@ pub fn create_bridge_with_base_and_path(
     let base_url = format!("{}/{}", mockito::server_url(), base);
 
     let url = Url::parse(base_url.as_str()).unwrap();
-    let bridge = Bridge::builder(url).build();
+    let bridge = Bridge::builder().build(url);
 
     (mock, bridge)
 }
@@ -44,7 +44,7 @@ pub fn create_bridge_with_path(status_code: usize, body: &str, path: &str) -> (M
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder(url).build();
+    let bridge = Bridge::builder().build(url);
 
     (mock, bridge)
 }
@@ -68,7 +68,7 @@ pub fn create_bridge_with_path_and_header(
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder(url).build();
+    let bridge = Bridge::builder().build(url);
 
     (mock, bridge)
 }
@@ -86,7 +86,7 @@ pub fn create_bridge_with_raw_body_matcher(body: &str) -> (Mock, Bridge) {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder(url).build();
+    let bridge = Bridge::builder().build(url);
 
     (mock, bridge)
 }
@@ -104,7 +104,7 @@ pub fn create_bridge_with_header_matcher((name, value): (&str, &str)) -> (Mock, 
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder(url).build();
+    let bridge = Bridge::builder().build(url);
 
     (mock, bridge)
 }
@@ -122,7 +122,7 @@ pub fn create_bridge_with_user_agent(user_agent: &str) -> (Mock, Bridge) {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder(url).with_user_agent(user_agent).build();
+    let bridge = Bridge::builder().with_user_agent(user_agent).build(url);
 
     (mock, bridge)
 }
@@ -140,7 +140,7 @@ pub fn create_bridge_with_json_body_matcher(json: serde_json::Value) -> (Mock, B
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder(url).build();
+    let bridge = Bridge::builder().build(url);
 
     (mock, bridge)
 }
@@ -159,7 +159,7 @@ pub fn create_bridge_with_binary_body_matcher(body: &[u8]) -> (Mock, Bridge) {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder(url).build();
+    let bridge = Bridge::builder().build(url);
 
     (mock, bridge)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
 use mockito::{mock, BinaryBody, Matcher, Mock};
 use prima_bridge::prelude::*;
+use prima_bridge::BridgeBuilder;
 use reqwest::Url;
 
 pub fn create_bridge(status_code: usize, body: &str) -> (Mock, Bridge) {
@@ -26,7 +27,7 @@ pub fn create_bridge_with_base_and_path(
     let base_url = format!("{}/{}", mockito::server_url(), base);
 
     let url = Url::parse(base_url.as_str()).unwrap();
-    let bridge = Bridge::new(url);
+    let bridge = BridgeBuilder::create(url).build();
 
     (mock, bridge)
 }
@@ -44,7 +45,7 @@ pub fn create_bridge_with_path(status_code: usize, body: &str, path: &str) -> (M
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::new(url);
+    let bridge = BridgeBuilder::create(url).build();
 
     (mock, bridge)
 }
@@ -68,7 +69,7 @@ pub fn create_bridge_with_path_and_header(
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::new(url);
+    let bridge = BridgeBuilder::create(url).build();
 
     (mock, bridge)
 }
@@ -86,7 +87,7 @@ pub fn create_bridge_with_raw_body_matcher(body: &str) -> (Mock, Bridge) {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::new(url);
+    let bridge = BridgeBuilder::create(url).build();
 
     (mock, bridge)
 }
@@ -104,7 +105,7 @@ pub fn create_bridge_with_header_matcher((name, value): (&str, &str)) -> (Mock, 
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::new(url);
+    let bridge = BridgeBuilder::create(url).build();
 
     (mock, bridge)
 }
@@ -122,7 +123,9 @@ pub fn create_bridge_with_user_agent(user_agent: &str) -> (Mock, Bridge) {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::with_user_agent(url, user_agent);
+    let bridge = BridgeBuilder::create(url)
+        .with_user_agent(user_agent)
+        .build();
 
     (mock, bridge)
 }
@@ -140,7 +143,7 @@ pub fn create_bridge_with_json_body_matcher(json: serde_json::Value) -> (Mock, B
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::new(url);
+    let bridge = BridgeBuilder::create(url).build();
 
     (mock, bridge)
 }
@@ -159,7 +162,7 @@ pub fn create_bridge_with_binary_body_matcher(body: &[u8]) -> (Mock, Bridge) {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::new(url);
+    let bridge = BridgeBuilder::create(url).build();
 
     (mock, bridge)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,5 @@
 use mockito::{mock, BinaryBody, Matcher, Mock};
 use prima_bridge::prelude::*;
-use prima_bridge::BridgeBuilder;
 use reqwest::Url;
 
 pub fn create_bridge(status_code: usize, body: &str) -> (Mock, Bridge) {
@@ -27,7 +26,7 @@ pub fn create_bridge_with_base_and_path(
     let base_url = format!("{}/{}", mockito::server_url(), base);
 
     let url = Url::parse(base_url.as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url).build();
+    let bridge = Bridge::builder(url).build();
 
     (mock, bridge)
 }
@@ -45,7 +44,7 @@ pub fn create_bridge_with_path(status_code: usize, body: &str, path: &str) -> (M
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url).build();
+    let bridge = Bridge::builder(url).build();
 
     (mock, bridge)
 }
@@ -69,7 +68,7 @@ pub fn create_bridge_with_path_and_header(
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url).build();
+    let bridge = Bridge::builder(url).build();
 
     (mock, bridge)
 }
@@ -87,7 +86,7 @@ pub fn create_bridge_with_raw_body_matcher(body: &str) -> (Mock, Bridge) {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url).build();
+    let bridge = Bridge::builder(url).build();
 
     (mock, bridge)
 }
@@ -105,7 +104,7 @@ pub fn create_bridge_with_header_matcher((name, value): (&str, &str)) -> (Mock, 
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url).build();
+    let bridge = Bridge::builder(url).build();
 
     (mock, bridge)
 }
@@ -123,9 +122,7 @@ pub fn create_bridge_with_user_agent(user_agent: &str) -> (Mock, Bridge) {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url)
-        .with_user_agent(user_agent)
-        .build();
+    let bridge = Bridge::builder(url).with_user_agent(user_agent).build();
 
     (mock, bridge)
 }
@@ -143,7 +140,7 @@ pub fn create_bridge_with_json_body_matcher(json: serde_json::Value) -> (Mock, B
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url).build();
+    let bridge = Bridge::builder(url).build();
 
     (mock, bridge)
 }
@@ -162,7 +159,7 @@ pub fn create_bridge_with_binary_body_matcher(body: &[u8]) -> (Mock, Bridge) {
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = BridgeBuilder::create(url).build();
+    let bridge = Bridge::builder(url).build();
 
     (mock, bridge)
 }


### PR DESCRIPTION
I've just deprecated the actual new and with_user_agent functions.
New features (like auth0) should be built upon the builder and not on the deprecated constructor.
What do you think?