### PR TITLE
[PLATFORM-499]: [Bridge.rs] Update breaking dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+### Changed
+
+- removed `block_modes` deprecated dependency in favour of the new `cbc` dependency
+
 ## [0.12.0]
 
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["async", "tracing_opentelemetry"]
 async = ["reqwest", "futures", "futures-util"]
 tracing_opentelemetry = ["opentelemetry", "tracing", "tracing-opentelemetry"]
 gzip = ["reqwest/gzip"]
-auth0 = ["tokio", "rand", "redis", "jsonwebtoken", "chrono", "chrono-tz", "aes", "block-modes", "dashmap", "tracing"]
+auth0 = ["tokio", "rand", "redis", "jsonwebtoken", "chrono", "chrono-tz", "aes", "cbc", "dashmap", "tracing"]
 
 [dependencies]
 reqwest = { version = "0.11.9", features = ["json", "multipart"], optional = true }
@@ -33,8 +33,8 @@ redis = { version = "0.21.5", features = ["tokio-comp"], optional = true }
 rand = { version = "0.8.4", optional = true }
 chrono = { version = "^0.4", features = ["serde"], optional = true }
 chrono-tz = { version = "^0.6", optional = true }
-aes = { version = "0.7.5", optional = true }
-block-modes = { version = "0.8.1", optional = true }
+aes = { version = "0.8.1", optional = true }
+cbc = { version = "0.1.2", features = ["std"], optional = true }
 dashmap = { version = "5.1.0", optional = true }
 
 [dev-dependencies]

--- a/src/auth0/cache/crypto.rs
+++ b/src/auth0/cache/crypto.rs
@@ -17,7 +17,7 @@ pub fn encrypt<T: Serialize>(value_ref: &T, token_encryption_key_str: &str) -> R
 
     // `unwrap` here is fine because `IV` is set here and the only error returned is: `InvalidKeyIvLength`
     // and this must never happen
-    let mut buf = [0u8; 48];
+    let mut buf = vec![0u8; json.len()];
     buf[..json.len()].copy_from_slice(json.as_bytes());
     let ct = Aes256Enc::new(token_encryption_key_str.as_bytes().into(), IV.as_bytes().into())
         .encrypt_padded_mut::<Pkcs7>(&mut buf, json.len())

--- a/src/auth0/cache/crypto.rs
+++ b/src/auth0/cache/crypto.rs
@@ -1,20 +1,29 @@
-use aes::Aes256 as Aes256Alg;
-use block_modes::block_padding::Pkcs7;
-use block_modes::{BlockMode, Cbc};
+use aes::{
+    cipher::{block_padding::Pkcs7, BlockDecryptMut, BlockEncryptMut, KeyIvInit},
+    Aes256,
+};
+use cbc::{Decryptor, Encryptor};
 use serde::{Deserialize, Serialize};
 
 use crate::auth0::errors::Auth0Error;
 
-type Aes256 = Cbc<Aes256Alg, Pkcs7>;
+type Aes256Enc = Encryptor<Aes256>;
+type Aes256Dec = Decryptor<Aes256>;
 
 const IV: &str = "301a9e39735f4646";
 
 pub fn encrypt<T: Serialize>(value_ref: &T, token_encryption_key_str: &str) -> Result<Vec<u8>, Auth0Error> {
     let json: String = serde_json::to_string(value_ref)?;
+
     // `unwrap` here is fine because `IV` is set here and the only error returned is: `InvalidKeyIvLength`
     // and this must never happen
-    let cipher: Aes256 = Aes256::new_from_slices(token_encryption_key_str.as_bytes(), IV.as_bytes()).unwrap();
-    Ok(cipher.encrypt_vec(json.as_bytes()))
+    let mut buf = [0u8; 48];
+    buf[..json.len()].copy_from_slice(json.as_bytes());
+    let ct = Aes256Enc::new(token_encryption_key_str.as_bytes().into(), IV.as_bytes().into())
+        .encrypt_padded_mut::<Pkcs7>(&mut buf, json.len())
+        .unwrap();
+
+    Ok(ct.to_vec())
 }
 
 pub fn decrypt<T>(token_encryption_key_str: &str, encrypted: &[u8]) -> Result<T, Auth0Error>
@@ -23,7 +32,10 @@ where
 {
     // `unwrap` here is fine because `IV` is set here and the only error returned is: `InvalidKeyIvLength`
     // and this must never happen
-    let cipher: Aes256 = Aes256::new_from_slices(token_encryption_key_str.as_bytes(), IV.as_bytes()).unwrap();
-    let decrypted: Vec<u8> = cipher.decrypt_vec(encrypted)?;
-    Ok(serde_json::from_slice(decrypted.as_slice())?)
+    let mut buf = Vec::from(encrypted);
+    let pt = Aes256Dec::new(token_encryption_key_str.as_bytes().into(), IV.as_bytes().into())
+        .decrypt_padded_mut::<Pkcs7>(&mut buf)
+        .unwrap();
+
+    Ok(serde_json::from_slice(pt)?)
 }

--- a/src/auth0/errors.rs
+++ b/src/auth0/errors.rs
@@ -1,3 +1,4 @@
+use aes::cipher::inout::PadError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -17,5 +18,5 @@ pub enum Auth0Error {
     #[error("redis error: {0}")]
     RedisError(#[from] redis::RedisError),
     #[error(transparent)]
-    CryptoError(#[from] block_modes::BlockModeError),
+    CryptoError(#[from] PadError),
 }

--- a/src/auth0/errors.rs
+++ b/src/auth0/errors.rs
@@ -1,4 +1,4 @@
-use aes::cipher::inout::PadError;
+use aes::cipher::block_padding::UnpadError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -18,5 +18,5 @@ pub enum Auth0Error {
     #[error("redis error: {0}")]
     RedisError(#[from] redis::RedisError),
     #[error(transparent)]
-    CryptoError(#[from] PadError),
+    CryptoError(#[from] UnpadError),
 }


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-499

This PR tries to address the changes made to the block_modes and aes library i.e. the fact that block_modes is now deprecated and has been split into different packages.

