### PR TITLE
Prepare for 0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+## [0.13.0]
+
 ### Changed
 
 - removed `block_modes` deprecated dependency in favour of the new `cbc` dependency
@@ -176,7 +178,8 @@ Request::rest(&bridge).send()
 
 The old API is still available but deprecated. It will be removed soon.
 
-[Next]: https://github.com/primait/bridge.rs/compare/0.12.0...HEAD
+[Next]: https://github.com/primait/bridge.rs/compare/0.13.0...HEAD
+[0.13.0]: https://github.com/primait/bridge.rs/compare/0.12.0...0.13.0
 [0.12.0]: https://github.com/primait/bridge.rs/compare/0.11.0...0.12.0
 [0.11.0]: https://github.com/primait/bridge.rs/compare/0.10.0...0.11.0
 [0.10.0]: https://github.com/primait/bridge.rs/compare/0.9.2...0.10.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prima_bridge"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Matteo Giachino <matteog@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
It's 0.13.0 and not 0.12.1 because 624d04d introduced a (potentially breaking) change in the public API (https://github.com/primait/bridge.rs/commit/624d04d984b6ce7fe0c0a09fb3aaee25660c983a#diff-704184975b84cdeca63b3a491e93e3e35cf5ab6914110c4738e2ec8d75cba379R21)