### PR TITLE
[PLATFORM-638]: [Bridge.rs] Avoid cloning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use reqwest::Url;
 
 pub use self::{
     builder::BridgeBuilder,
-    request::{GraphQLRequest, Multipart, MultipartFile, Request},
+    request::{GraphQLRequest, Multipart, MultipartFile, Request, RestMultipart},
     response::graphql::{Error, ParsedGraphqlResponse, ParsedGraphqlResponseExt, PossiblyParsedData},
     response::Response,
 };

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 pub use body::{Body, GraphQLBody};
-pub use request_type::{GraphQLRequest, Multipart, MultipartFile, Request, RestRequest};
+pub use request_type::{GraphQLRequest, Multipart, MultipartFile, Request, RestMultipart, RestRequest};
 
 use crate::errors::{PrimaBridgeError, PrimaBridgeResult};
 use crate::{Bridge, Response};

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -7,8 +7,8 @@ use reqwest::{Method, Url};
 use serde::Serialize;
 use uuid::Uuid;
 
-pub use body::{Body, GraphQLBody};
-pub use request_type::{GraphQLRequest, Multipart, MultipartFile, Request, RestMultipart, RestRequest};
+pub use body::{Body, MultipartFile, GraphQLBody};
+pub use request_type::{GraphQLRequest, Multipart, Request, RestMultipart, RestRequest};
 
 use crate::errors::{PrimaBridgeError, PrimaBridgeResult};
 use crate::{Bridge, Response};

--- a/src/request/request_type/graphql.rs
+++ b/src/request/request_type/graphql.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
-use reqwest::multipart::{Form, Part};
+use reqwest::multipart::Form;
 use reqwest::{Method, Url};
 use serde::Serialize;
 use serde_json::{json, Map, Value};
@@ -13,6 +13,8 @@ use uuid::Uuid;
 use crate::errors::{PrimaBridgeError, PrimaBridgeResult};
 use crate::request::{Body, DeliverableRequest, GraphQLBody, RequestType};
 use crate::Bridge;
+
+pub use crate::request::body::MultipartFile;
 
 const VARIABLES: &str = "variables";
 const ZERO: &str = "0";
@@ -224,7 +226,6 @@ impl<'a> DeliverableRequest<'a> for GraphQLRequest<'a> {
 
 // The path in query variable. Eg: if query/mutation has a param named files (representing the
 // multipart upload) this should be something like `variables.files`
-#[derive(Debug)]
 pub enum Multipart {
     Single(Single),
     Multiple(Multiple),
@@ -240,55 +241,9 @@ impl Multipart {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct MultipartFile {
-    pub(crate) bytes: Vec<u8>,
-    pub(crate) name_opt: Option<String>,
-    pub(crate) mime_type_opt: Option<String>,
-}
-
-impl MultipartFile {
-    pub fn new(bytes: Vec<u8>) -> Self {
-        Self {
-            bytes,
-            name_opt: None,
-            mime_type_opt: None,
-        }
-    }
-
-    pub fn with_name(self, name: impl Into<String>) -> Self {
-        Self {
-            name_opt: Some(name.into()),
-            ..self
-        }
-    }
-
-    pub fn with_mime_type(self, mime_type: impl Into<String>) -> Self {
-        Self {
-            mime_type_opt: Some(mime_type.into()),
-            ..self
-        }
-    }
-
-    pub(crate) fn into_part(self) -> PrimaBridgeResult<Part> {
-        let len = self.bytes.len() as u64;
-        let mut part = Part::stream_with_length(self.bytes, len);
-        if let Some(name) = self.name_opt {
-            part = part.file_name(name);
-        }
-        if let Some(mime) = self.mime_type_opt {
-            part = part
-                .mime_str(mime.as_str())
-                .map_err(|_| PrimaBridgeError::InvalidMultipartFileMimeType(mime.to_string()))?;
-        }
-        Ok(part)
-    }
-}
-
-#[derive(Debug)]
 pub struct Single {
-    pub(crate) path: String,
-    pub(crate) file: MultipartFile,
+    path: String,
+    file: MultipartFile,
 }
 
 impl Single {
@@ -300,9 +255,8 @@ impl Single {
     }
 }
 
-#[derive(Debug)]
 pub struct Multiple {
-    pub(crate) map: HashMap<String, Vec<MultipartFile>>,
+    map: HashMap<String, Vec<MultipartFile>>,
 }
 
 impl Multiple {

--- a/src/request/request_type/graphql.rs
+++ b/src/request/request_type/graphql.rs
@@ -12,9 +12,7 @@ use uuid::Uuid;
 
 use crate::errors::{PrimaBridgeError, PrimaBridgeResult};
 use crate::request::{Body, DeliverableRequest, GraphQLBody, RequestType};
-use crate::Bridge;
-
-pub use crate::request::body::MultipartFile;
+use crate::{Bridge, MultipartFile};
 
 const VARIABLES: &str = "variables";
 const ZERO: &str = "0";

--- a/src/request/request_type/graphql.rs
+++ b/src/request/request_type/graphql.rs
@@ -444,7 +444,7 @@ mod tests {
 
         let variables: Value = Value::Null;
 
-        let req = GraphQLRequest::new_with_multipart(&bridge, ("query", Some(variables.clone())), multipart).unwrap();
+        let req = GraphQLRequest::new_with_multipart(&bridge, ("query", Some(variables)), multipart).unwrap();
 
         let body_str: String = (&req.body).into();
 
@@ -467,7 +467,7 @@ mod tests {
 
         let variables: Value = json!({"input": {"file": Value::String("ciao".to_string())}});
 
-        let req = GraphQLRequest::new_with_multipart(&bridge, ("query", Some(variables.clone())), multipart).unwrap();
+        let req = GraphQLRequest::new_with_multipart(&bridge, ("query", Some(variables)), multipart).unwrap();
 
         let body_str: String = (&req.body).into();
         let graphql_body: GraphQLBody<Value> = serde_json::from_str(body_str.as_str()).unwrap();
@@ -492,7 +492,7 @@ mod tests {
             "input": {"file": Value::String("ciao".to_string()), "desc": Value::String("desc".to_string())}
         });
 
-        let req = GraphQLRequest::new_with_multipart(&bridge, ("query", Some(variables.clone())), multipart).unwrap();
+        let req = GraphQLRequest::new_with_multipart(&bridge, ("query", Some(variables)), multipart).unwrap();
 
         let body_str: String = (&req.body).into();
         let graphql_body: GraphQLBody<Value> = serde_json::from_str(body_str.as_str()).unwrap();
@@ -559,7 +559,7 @@ mod tests {
 
         let variables: Value = json!({"input": {"files": Value::Array(vec![Value::Null, Value::Null])}});
 
-        let req = GraphQLRequest::new_with_multipart(&bridge, ("query", Some(variables.clone())), multipart).unwrap();
+        let req = GraphQLRequest::new_with_multipart(&bridge, ("query", Some(variables)), multipart).unwrap();
 
         let body_str: String = (&req.body).into();
         let graphql_body: GraphQLBody<Value> = serde_json::from_str(body_str.as_str()).unwrap();
@@ -581,7 +581,7 @@ mod tests {
 
         let variables: Value = json!({"input": {"files": Value::String("ciao".to_string())}});
 
-        let req = GraphQLRequest::new_with_multipart(&bridge, ("query", Some(variables.clone())), multipart).unwrap();
+        let req = GraphQLRequest::new_with_multipart(&bridge, ("query", Some(variables)), multipart).unwrap();
 
         let body_str: String = (&req.body).into();
         let graphql_body: GraphQLBody<Value> = serde_json::from_str(body_str.as_str()).unwrap();
@@ -603,7 +603,7 @@ mod tests {
 
         let variables: Value = Value::Null;
 
-        let req = GraphQLRequest::new_with_multipart(&bridge, ("query", Some(variables.clone())), multipart).unwrap();
+        let req = GraphQLRequest::new_with_multipart(&bridge, ("query", Some(variables)), multipart).unwrap();
 
         let body_str: String = (&req.body).into();
         let graphql_body: GraphQLBody<Value> = serde_json::from_str(body_str.as_str()).unwrap();

--- a/src/request/request_type/mod.rs
+++ b/src/request/request_type/mod.rs
@@ -1,7 +1,7 @@
 pub use graphql::GraphQLRequest;
 pub use graphql::{Multipart, MultipartFile};
 use reqwest::Method;
-pub use rest::RestRequest;
+pub use rest::{RestMultipart, RestRequest};
 use serde::Serialize;
 
 use crate::errors::PrimaBridgeResult;

--- a/src/request/request_type/mod.rs
+++ b/src/request/request_type/mod.rs
@@ -1,5 +1,5 @@
 pub use graphql::GraphQLRequest;
-pub use graphql::{Multipart, MultipartFile};
+pub use graphql::Multipart;
 use reqwest::Method;
 pub use rest::{RestMultipart, RestRequest};
 use serde::Serialize;

--- a/src/request/request_type/rest.rs
+++ b/src/request/request_type/rest.rs
@@ -48,12 +48,13 @@ impl<'a> RestRequest<'a> {
         }
     }
 
+    /// Request method defaults to `POST`
     pub fn new_with_multipart(bridge: &'a Bridge, multipart: RestMultipart) -> Self {
         Self {
+            method: Method::POST,
             id: Uuid::new_v4(),
             bridge,
             body: Default::default(),
-            method: Default::default(), // GET
             path: Default::default(),
             timeout: Duration::from_secs(60),
             query_pairs: Default::default(),

--- a/tests/async_bridge/graphql.rs
+++ b/tests/async_bridge/graphql.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 use std::fs;
 
-use mockito;
 use mockito::{mock, Matcher, Mock};
 use reqwest::header::{HeaderName, HeaderValue};
 use reqwest::Url;
@@ -91,7 +90,7 @@ async fn error_response_parser() -> Result<(), Box<dyn Error>> {
         .await?;
     let parsed_response = response.parse_graphql_response::<GqlResponse>()?;
 
-    assert!(!parsed_response.is_ok());
+    assert!(parsed_response.is_err());
     assert!(parsed_response.has_parsed_data());
     assert_eq!(1, parsed_response.get_errors().len());
 
@@ -112,7 +111,7 @@ async fn error_response_parser_with_non_null_element() -> Result<(), Box<dyn Err
         .await?;
     let parsed_response = response.parse_graphql_response::<GqlResponse>()?;
 
-    assert!(!parsed_response.is_ok());
+    assert!(parsed_response.is_err());
     assert!(parsed_response.has_parsed_data());
     assert_eq!(1, parsed_response.get_errors().len());
 
@@ -129,7 +128,7 @@ async fn error_response_parser_with_error() -> Result<(), Box<dyn Error>> {
         .await?;
     let parsed_response = response.parse_graphql_response::<GqlResponse>()?;
 
-    assert!(!parsed_response.is_ok());
+    assert!(parsed_response.is_err());
     assert!(!parsed_response.has_parsed_data());
     assert_eq!(1, parsed_response.get_errors().len());
 

--- a/tests/async_bridge/rest.rs
+++ b/tests/async_bridge/rest.rs
@@ -1,10 +1,15 @@
+use std::collections::HashMap;
 use std::error::Error;
+use std::iter::FromIterator;
 
-use reqwest::header::{HeaderName, HeaderValue};
+use reqwest::{
+    header::{HeaderName, HeaderValue},
+    Method,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use prima_bridge::prelude::*;
+use prima_bridge::{prelude::*, MultipartFile, RestMultipart};
 
 use crate::common::*;
 
@@ -155,6 +160,87 @@ async fn equal_headers_should_be_sent_only_once() -> Result<(), Box<dyn Error>> 
 
     let headers = req.get_custom_headers();
     assert_eq!(HeaderValue::from_str("value").ok().as_ref(), headers.get("x-test"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn multipart_rest_single_file() -> Result<(), Box<dyn Error>> {
+    let _mock = mockito::mock("POST", "/")
+        .with_status(200)
+        .with_body("{\"hello\": \"world!\"}")
+        .match_header("Content-Type", mockito::Matcher::Regex(r#"^multipart/form-data"#.to_string()))
+        .match_body(mockito::Matcher::Regex(r#"Content-Disposition: form-data; name="my_single_file"; filename="hello_world\.txt"\s+Content-Type: text/plain\s+Hello, world!"#.to_string()))
+        .create();
+
+    let bridge = Bridge::builder().build(mockito::server_url().parse().unwrap());
+
+    let multipart = RestMultipart::single(
+        "my_single_file",
+        MultipartFile::new(b"Hello, world!".to_vec())
+            .with_name("hello_world.txt")
+            .with_mime_type("text/plain"),
+    );
+
+    let result: String = RestRequest::new_with_multipart(&bridge, multipart)
+        .method(Method::POST)
+        .send()
+        .await?
+        .get_data(&["hello"])?;
+    assert_eq!(result, "world!");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn multipart_rest_multi_file() -> Result<(), Box<dyn Error>> {
+    // Because a HashMap is used in RestMultipart::multiple, the order of each file is undefined, so the
+    // matching Regex must be able to match the files in either order.
+    let re_first_file = r#"Content-Disposition: form-data; name="first_file"; filename="hello_world\.txt"\s+Content-Type: text/plain\s+Hello, world!"#;
+    let re_second_file = r#"Content-Disposition: form-data; name="second_file"; filename="goodbye_world\.dat"\s+Content-Type: application/octet-stream\s+Goodbye, world!"#;
+    let re_body = format!(
+        // This will generate a regular expression that matches re_first_file...re_second_file OR re_second_file...re_first_file
+        r#"{re_first_file}[\s\S]+\S[\s\S]+{re_second_file}|{re_second_file}[\s\S]+\S[\s\S]+{re_first_file}"#,
+        re_first_file = re_first_file,
+        re_second_file = re_second_file
+    );
+
+    let _mock = mockito::mock("POST", "/")
+        .with_status(200)
+        .with_body("{\"hello\": \"world!\"}")
+        .match_header(
+            "Content-Type",
+            mockito::Matcher::Regex(r#"^multipart/form-data"#.to_string()),
+        )
+        .match_body(mockito::Matcher::Regex(re_body))
+        .create();
+
+    let bridge = Bridge::builder().build(mockito::server_url().parse().unwrap());
+
+    let multipart = RestMultipart::multiple(HashMap::from_iter(
+        [
+            (
+                "first_file".to_string(),
+                MultipartFile::new(b"Hello, world!".to_vec())
+                    .with_name("hello_world.txt")
+                    .with_mime_type("text/plain"),
+            ),
+            (
+                "second_file".to_string(),
+                MultipartFile::new(b"Goodbye, world!".to_vec())
+                    .with_name("goodbye_world.dat")
+                    .with_mime_type("application/octet-stream"),
+            ),
+        ]
+        .into_iter(),
+    ));
+
+    let result: String = RestRequest::new_with_multipart(&bridge, multipart)
+        .method(Method::POST)
+        .send()
+        .await?
+        .get_data(&["hello"])?;
+    assert_eq!(result, "world!");
 
     Ok(())
 }


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-638

This PR reduces the amount of unnecessary clones across the codebase.

This is a **breaking change** because we change the public API to consume the request builder on `send`. This is necessary to avoid cloning the request body multiple times throughout the request journey, which is contributing to strained memory pressure in production.
