### PR TITLE
added method to builder to specify redirect policy

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,9 +1,9 @@
-use reqwest::{redirect::Policy, Url};
+use reqwest::Url;
 
 /// auth0 related functions
 #[cfg(feature = "auth0")]
 use crate::auth0;
-use crate::Bridge;
+use crate::{redirect::Policy, Bridge};
 
 /// A builder for creating [Bridge] instances.
 pub struct BridgeBuilder {
@@ -37,9 +37,15 @@ impl BridgeBuilder {
     }
 
     pub fn with_redirect_policy(self, policy: Policy) -> Self {
-        let client_builder = self.client_builder.redirect(policy);
+        let client_builder = self.client_builder.redirect(policy.into());
 
-        Self { client_builder, ..self }
+        #[cfg(not(feature = "auth0"))]
+        let builder = Self { client_builder };
+
+        #[cfg(feature = "auth0")]
+        let builder = Self { client_builder, ..self };
+
+        builder
     }
 
     // add auth0 capabilities to this bridge

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use reqwest::{Url, redirect::Policy};
+use reqwest::{redirect::Policy, Url};
 
 /// auth0 related functions
 #[cfg(feature = "auth0")]
@@ -39,10 +39,7 @@ impl BridgeBuilder {
     pub fn with_redirect_policy(self, policy: Policy) -> Self {
         let client_builder = self.client_builder.redirect(policy);
 
-        Self {
-            client_builder,
-            ..self
-        }
+        Self { client_builder, ..self }
     }
 
     // add auth0 capabilities to this bridge

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use reqwest::Url;
+use reqwest::{Url, redirect::Policy};
 
 /// auth0 related functions
 #[cfg(feature = "auth0")]
@@ -34,6 +34,15 @@ impl BridgeBuilder {
         };
 
         builder
+    }
+
+    pub fn with_redirect_policy(self, policy: Policy) -> Self {
+        let client_builder = self.client_builder.redirect(policy);
+
+        Self {
+            client_builder,
+            ..self
+        }
     }
 
     // add auth0 capabilities to this bridge

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub use self::{
 mod builder;
 mod errors;
 pub mod prelude;
+pub mod redirect;
 mod request;
 mod response;
 

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,0 +1,14 @@
+use reqwest::redirect::Policy as ReqwestPolicy;
+pub enum Policy {
+    NoFollow,
+    Limited(usize),
+}
+
+impl From<Policy> for ReqwestPolicy {
+    fn from(policy: Policy) -> Self {
+        match policy {
+            Policy::NoFollow => ReqwestPolicy::none(),
+            Policy::Limited(max) => ReqwestPolicy::limited(max),
+        }
+    }
+}

--- a/tests/async_bridge/rest.rs
+++ b/tests/async_bridge/rest.rs
@@ -1,15 +1,12 @@
 use std::error::Error;
 
-use reqwest::{
-    header::{HeaderName, HeaderValue},
-    redirect::Policy,
-};
+use reqwest::header::{HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use prima_bridge::prelude::*;
-
 use crate::common::*;
+use prima_bridge::prelude::*;
+use prima_bridge::redirect::Policy;
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Serialize)]
 struct Data {
@@ -35,7 +32,7 @@ async fn request_with_redirect_policy_none() -> Result<(), Box<dyn Error>> {
 
     let redirect_to = format!("{}/destination", mockito::server_url());
     let body = "{\"before\": \"redirect\"}";
-    let (_m, bridge) = create_bridge_with_redirect(302, body, "/", &redirect_to, Policy::none());
+    let (_m, bridge) = create_bridge_with_redirect(302, body, "/", &redirect_to, Policy::NoFollow);
 
     let result: Response = RestRequest::new(&bridge)
         .ignore_status_code()
@@ -61,7 +58,7 @@ async fn request_with_redirect_policy_follow() -> Result<(), Box<dyn Error>> {
 
     let redirect_to = format!("{}/destination", mockito::server_url());
     let body = "{\"before\": \"redirect\"}";
-    let (_m, bridge) = create_bridge_with_redirect(302, body, "/", &redirect_to, Policy::limited(2));
+    let (_m, bridge) = create_bridge_with_redirect(302, body, "/", &redirect_to, Policy::Limited(2));
 
     let result: Response = RestRequest::new(&bridge)
         .ignore_status_code()

--- a/tests/async_bridge/rest.rs
+++ b/tests/async_bridge/rest.rs
@@ -1,6 +1,9 @@
 use std::error::Error;
 
-use reqwest::{header::{HeaderName, HeaderValue}, redirect::Policy};
+use reqwest::{
+    header::{HeaderName, HeaderValue},
+    redirect::Policy,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -42,7 +45,8 @@ async fn request_with_redirect_policy_none() -> Result<(), Box<dyn Error>> {
 
     assert!(result.status_code().is_redirection());
     assert_eq!(result.headers().get("Location").unwrap().to_str().unwrap(), redirect_to);
-    let response : serde_json::Value = serde_json::from_slice(result.raw_body()).expect("Failed to deserialize response");
+    let response: serde_json::Value =
+        serde_json::from_slice(result.raw_body()).expect("Failed to deserialize response");
     assert_eq!(response, json!({"before": "redirect"}));
 
     Ok(())
@@ -54,7 +58,7 @@ async fn request_with_redirect_policy_follow() -> Result<(), Box<dyn Error>> {
         .with_status(200)
         .with_body("{\"after\": \"redirect\"}")
         .create();
-    
+
     let redirect_to = format!("{}/destination", mockito::server_url());
     let body = "{\"before\": \"redirect\"}";
     let (_m, bridge) = create_bridge_with_redirect(302, body, "/", &redirect_to, Policy::limited(2));
@@ -66,7 +70,8 @@ async fn request_with_redirect_policy_follow() -> Result<(), Box<dyn Error>> {
         .expect("request failed");
 
     assert!(result.status_code().is_success());
-    let response : serde_json::Value = serde_json::from_slice(result.raw_body()).expect("Failed to deserialize response");
+    let response: serde_json::Value =
+        serde_json::from_slice(result.raw_body()).expect("Failed to deserialize response");
     assert_eq!(response, json!({"after": "redirect"}));
 
     Ok(())

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,5 @@
 use mockito::{mock, BinaryBody, Matcher, Mock};
-use reqwest::{Url, redirect::Policy};
+use reqwest::{redirect::Policy, Url};
 
 use prima_bridge::prelude::*;
 
@@ -155,7 +155,7 @@ pub fn create_bridge_with_redirect(
     body: &str,
     path: &str,
     redirect_to: &str,
-    policy: Policy
+    policy: Policy,
 ) -> (Mock, Bridge) {
     let mock = mock("GET", path)
         .match_header(
@@ -168,9 +168,7 @@ pub fn create_bridge_with_redirect(
         .create();
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
-    let bridge = Bridge::builder()
-        .with_redirect_policy(policy)
-        .build(url);
+    let bridge = Bridge::builder().with_redirect_policy(policy).build(url);
 
     (mock, bridge)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,5 @@
 use mockito::{mock, BinaryBody, Matcher, Mock};
-use reqwest::Url;
+use reqwest::{Url, redirect::Policy};
 
 use prima_bridge::prelude::*;
 
@@ -146,6 +146,31 @@ pub fn create_bridge_with_binary_body_matcher(body: &[u8]) -> (Mock, Bridge) {
 
     let url = Url::parse(mockito::server_url().as_str()).unwrap();
     let bridge = Bridge::builder().build(url);
+
+    (mock, bridge)
+}
+
+pub fn create_bridge_with_redirect(
+    status_code: usize,
+    body: &str,
+    path: &str,
+    redirect_to: &str,
+    policy: Policy
+) -> (Mock, Bridge) {
+    let mock = mock("GET", path)
+        .match_header(
+            "x-request-id",
+            Matcher::Regex(r"\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b".to_string()),
+        )
+        .with_status(status_code)
+        .with_header("Location", redirect_to)
+        .with_body(body)
+        .create();
+
+    let url = Url::parse(mockito::server_url().as_str()).unwrap();
+    let bridge = Bridge::builder()
+        .with_redirect_policy(policy)
+        .build(url);
 
     (mock, bridge)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,7 @@
 use mockito::{mock, BinaryBody, Matcher, Mock};
-use reqwest::{redirect::Policy, Url};
-
 use prima_bridge::prelude::*;
+use prima_bridge::redirect::Policy;
+use reqwest::Url;
 
 #[allow(unused)]
 pub fn enable_mockito_logging() {


### PR DESCRIPTION
Added method with_redirect_policy to Bridge builder in order to be able to specify redirect policy of the request client.
This is useful for instance in a test to test the response with a status code of redirection.
