### PR TITLE
Add redis-tls feature to expose redis crate tls & tokio-native-tls-comp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ default = ["tracing_opentelemetry"]
 tracing_opentelemetry = ["opentelemetry", "tracing", "tracing-opentelemetry"]
 gzip = ["reqwest/gzip"]
 auth0 = ["rand", "redis", "jsonwebtoken", "chrono", "chrono-tz", "aes", "cbc", "dashmap", "tracing"]
+redis-tls = ["redis/tls", "redis/tokio-native-tls-comp"]
 
 [dependencies]
 reqwest = { version = "0.11.9", features = ["json", "multipart", "stream"] }


### PR DESCRIPTION
This change is required to make `es-be` working in production env where we have secure connection in place for the Redis cluster. Staging doesn't have this enabled.