### PR TITLE
get cached token before refreshing

### DIFF
--- a/src/auth0/mod.rs
+++ b/src/auth0/mod.rs
@@ -69,7 +69,11 @@ async fn start(
 
         loop {
             ticker.tick().await;
-            let token: Token = read(&token_lock);
+
+            let token: Token = match cache.get_token().await? {
+                Some(token) => token,
+                None => read(&token_lock),
+            };
 
             if token.needs_refresh(&config) {
                 tracing::info!("Refreshing JWT and JWKS");
@@ -96,6 +100,8 @@ async fn start(
                     }
                     Err(error) => tracing::error!("Failed to fetch JWT. Reason: {:?}", error),
                 }
+            } else if (token.expire_date() > read(&token_lock).expire_date()) {
+                write(&token_lock, token);
             }
         }
     })


### PR DESCRIPTION
Updates the refresh logic to consider cached tokens before refreshing.
If a cached token is more recent than the one stored internally and does not need a refresh it simply updates the internal stored token.

This should reduce the number of token renewals to `1 * #audience` from the current `#nodes * #audience` when using a redis cache.

Background: https://prima.slack.com/archives/C01P553CP38/p1666623335650759?thread_ts=1666597527.870059&cid=C01P553CP38