### PR TITLE
Make pool_max_idle_per_host configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.3] - 2022-11-02
+
+### Added
+
+- Added method to customize `pool_max_idle_per_host` from the builder
+
 ## [0.14.2] - 2022-10-04
 
 ### Added
@@ -274,7 +280,9 @@ Request::rest(&bridge).send()
 The old API is still available but deprecated. It will be removed soon.
 
 
-[Unreleased]: https://github.com/primait/bridge.rs/compare/0.14.2...HEAD
+
+[Unreleased]: https://github.com/primait/bridge.rs/compare/0.14.3...HEAD
+[0.14.3]: https://github.com/primait/bridge.rs/compare/0.14.2...0.14.3
 [0.14.2]: https://github.com/primait/bridge.rs/compare/0.14.1...0.14.2
 [0.14.1]: https://github.com/primait/bridge.rs/compare/0.14.0...0.14.1
 [0.14.0]: https://github.com/primait/bridge.rs/compare/0.13.1...0.14.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prima_bridge"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["Matteo Giachino <matteog@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -47,6 +47,18 @@ impl BridgeBuilder {
         builder
     }
 
+    pub fn with_pool_max_idle_per_host(self, max: usize) -> Self {
+        let client_builder = self.client_builder.pool_max_idle_per_host(max);
+
+        #[cfg(not(feature = "auth0"))]
+        let builder = Self { client_builder };
+
+        #[cfg(feature = "auth0")]
+        let builder = Self { client_builder, ..self };
+
+        builder
+    }
+
     /// Adds Auth0 JWT authentication to the requests made by the [Bridge].
     #[cfg_attr(docsrs, doc(cfg(feature = "auth0")))]
     #[cfg(feature = "auth0")]


### PR DESCRIPTION
This PR allows to configure the [`pool_max_idle_per_host`](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.pool_max_idle_per_host) parameter for `reqwest`/`hyper` from the builder.

The reason for this change is that on `es-be` we'd like to have idle connections be closed before they are reused, to prevent a race condition where the server would close the idle connection at the same moment that a client tried to use it.

I haven't found any unit test for the builder, so I didn't add any new test for this new functionality either. Please let me know if I missed something.