### PR TITLE
[PLATFORM-1201]: Update OTEL requirement to allow v0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,53 +1,54 @@
 [package]
-name = "prima_bridge"
-version = "0.14.4"
 authors = ["Matteo Giachino <matteog@gmail.com>"]
+description = "A library to implement the bridge pattern"
 edition = "2021"
 license = "MIT"
-description = "A library to implement the bridge pattern"
-repository = "https://github.com/primait/bridge.rs"
+name = "prima_bridge"
 readme = "README.md"
+repository = "https://github.com/primait/bridge.rs"
+version = "0.14.4"
 
 [features]
-default = ["tracing_opentelemetry"]
-tracing_opentelemetry = ["opentelemetry", "tracing", "tracing-opentelemetry"]
-gzip = ["reqwest/gzip"]
 auth0 = ["rand", "redis", "jsonwebtoken", "chrono", "chrono-tz", "aes", "cbc", "dashmap", "tracing"]
+default = ["tracing_opentelemetry"]
+gzip = ["reqwest/gzip"]
 redis-tls = ["redis/tls", "redis/tokio-native-tls-comp"]
+tracing_opentelemetry = ["opentelemetry", "tracing", "tracing-opentelemetry"]
 
 [dependencies]
-reqwest = { version = "0.11.9", features = ["json", "multipart", "stream"] }
+aes = {version = "0.8", optional = true}
+aes = {version = "0.8.1", optional = true}
+async-trait = "0.1"
+async-trait = "0.1.52"
 bytes = "1.2.1"
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.78"
-thiserror = "1.0.30"
-tokio = { version = "1.16.1", features = ["macros", "rt-multi-thread", "fs"] }
-uuid = { version = ">=0.7.0, <2.0.0", features = ["serde", "v4"] }
+cbc = {version = "0.1.2", features = ["std"], optional = true}
+chrono = {version = "0.4.26", default-features = false, features = ["clock", "std", "serde"], optional = true}
+chrono-tz = {version = "0.6.3", optional = true}
+dashmap = {version = "5.1.0", optional = true}
 futures = "0.3.21"
 futures-util = "0.3.21"
-opentelemetry = { version = ">=0.17.0, <=0.19.0", optional = true }
-tracing = { version = "0.1.30", optional = true }
-tracing-opentelemetry = { version = ">=0.17.0, <=0.20.0", optional = true }
-async-trait = "0.1.52"
-jsonwebtoken = { version = "8.0.1", optional = true }
-redis = { version = "0.23.0", features = ["tokio-comp"], optional = true }
-rand = { version = "0.8.4", optional = true }
-chrono = { version = "0.4.26", default-features = false, features = ["clock", "std", "serde"], optional = true }
-chrono-tz = { version = "0.6.3", optional = true }
-aes = { version = "0.8.1", optional = true }
-cbc = { version = "0.1.2", features = ["std"], optional = true }
-dashmap = { version = "5.1.0", optional = true }
+jsonwebtoken = {version = "8.0.1", optional = true}
+opentelemetry = {version = ">=0.17.0, <=0.19.0", optional = true}
+rand = {version = "0.8.4", optional = true}
+redis = {version = "0.23.0", features = ["tokio-comp"], optional = true}
+serde = {version = "1.0.136", features = ["derive"]}
+serde_json = "1.0.78"
+thiserror = "1.0.30"
+tokio = {version = "1.16.1", features = ["macros", "rt-multi-thread", "fs"]}
+tracing = {version = "0.1.30", optional = true}
+tracing-opentelemetry = {version = ">=0.17.0, <=0.19.0", optional = true}
+uuid = {version = ">=0.7.0, <2.0.0", features = ["serde", "v4"]}
 
 [dev-dependencies]
-tokio = { version = "1.16.1", features = ["macros", "rt-multi-thread"] }
-mockito = "1.0.0"
-tokio-test = "0.4.2"
-flate2 = "1.0.22"
 env_logger = "0"
+flate2 = "1.0"
+mockito = "1.0"
+tokio = {version = "1.16", features = ["macros", "rt-multi-thread"]}
+tokio-test = "0.4"
 
 [profile.release]
-lto = "thin"
 codegen-units = 1
+lto = "thin"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ dashmap = {version = "5.1", optional = true}
 futures = "0.3"
 futures-util = "0.3"
 jsonwebtoken = {version = "8.0", optional = true}
-opentelemetry = {version = ">=0.17.0, <=0.19.0", optional = true}
+opentelemetry = {version = ">=0.17, <=0.20", optional = true}
 rand = {version = "0.8", optional = true}
 redis = {version = "0.23", features = ["tokio-comp"], optional = true}
 reqwest = {version = "0.11", features = ["json", "multipart", "stream"]}
@@ -35,7 +35,7 @@ serde_json = "1.0"
 thiserror = "1.0"
 tokio = {version = "1.16", features = ["macros", "rt-multi-thread", "fs"]}
 tracing = {version = "0.1", optional = true}
-tracing-opentelemetry = {version = ">=0.17.0, <=0.19.0", optional = true}
+tracing-opentelemetry = {version = ">=0.17, <=0.20", optional = true}
 uuid = {version = ">=0.7.0, <2.0.0", features = ["serde", "v4"]}
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,25 +17,24 @@ tracing_opentelemetry = ["opentelemetry", "tracing", "tracing-opentelemetry"]
 
 [dependencies]
 aes = {version = "0.8", optional = true}
-aes = {version = "0.8.1", optional = true}
 async-trait = "0.1"
-async-trait = "0.1.52"
-bytes = "1.2.1"
-cbc = {version = "0.1.2", features = ["std"], optional = true}
-chrono = {version = "0.4.26", default-features = false, features = ["clock", "std", "serde"], optional = true}
-chrono-tz = {version = "0.6.3", optional = true}
-dashmap = {version = "5.1.0", optional = true}
-futures = "0.3.21"
-futures-util = "0.3.21"
-jsonwebtoken = {version = "8.0.1", optional = true}
+bytes = "1.2"
+cbc = {version = "0.1", features = ["std"], optional = true}
+chrono = {version = "0.4", default-features = false, features = ["clock", "std", "serde"], optional = true}
+chrono-tz = {version = "0.6", optional = true}
+dashmap = {version = "5.1", optional = true}
+futures = "0.3"
+futures-util = "0.3"
+jsonwebtoken = {version = "8.0", optional = true}
 opentelemetry = {version = ">=0.17.0, <=0.19.0", optional = true}
-rand = {version = "0.8.4", optional = true}
-redis = {version = "0.23.0", features = ["tokio-comp"], optional = true}
-serde = {version = "1.0.136", features = ["derive"]}
-serde_json = "1.0.78"
-thiserror = "1.0.30"
-tokio = {version = "1.16.1", features = ["macros", "rt-multi-thread", "fs"]}
-tracing = {version = "0.1.30", optional = true}
+rand = {version = "0.8", optional = true}
+redis = {version = "0.23", features = ["tokio-comp"], optional = true}
+reqwest = {version = "0.11", features = ["json", "multipart", "stream"]}
+serde = {version = "1.0", features = ["derive"]}
+serde_json = "1.0"
+thiserror = "1.0"
+tokio = {version = "1.16", features = ["macros", "rt-multi-thread", "fs"]}
+tracing = {version = "0.1", optional = true}
 tracing-opentelemetry = {version = ">=0.17.0, <=0.19.0", optional = true}
 uuid = {version = ">=0.7.0, <2.0.0", features = ["serde", "v4"]}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN groupadd -g 1000 app && \
     cargo install cargo-make && \
     rustup component add clippy rustfmt
 
-# Serve per avere l'owner dei file scritti dal container uguale all'utente Linux sull'host
 USER app
 
 ENTRYPOINT ["./entrypoint"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3"
+services:
+  bridge:
+    build:
+      context: .
+    environment:
+      BUILD_ENV: dev
+      CARGO_HOME: /home/app/.cargo
+      CARGO_TARGET_DIR: /home/app/target
+      CARGO_MAKE_DISABLE_UPDATE_CHECK: 1
+    volumes:
+      - ".:/code"
+      - "app:/home/app/"
+      - "~/.aws:/home/app/.aws"
+      - "~/.ssh:/home/app/.ssh"
+      - "~/.gitconfig:/home/app/.gitconfig"
+      - "~/.gitignore:/home/app/.gitignore"
+    tty: true
+    stdin_open: true
+
+volumes:
+  app:

--- a/src/auth0/mod.rs
+++ b/src/auth0/mod.rs
@@ -40,7 +40,7 @@ impl Auth0 {
         let jwks_lock: Arc<RwLock<JsonWebKeySet>> = Arc::new(RwLock::new(jwks));
         let token_lock: Arc<RwLock<Token>> = Arc::new(RwLock::new(token));
 
-        let _handle: JoinHandle<()> = start(
+        start(
             jwks_lock.clone(),
             token_lock.clone(),
             client_ref.clone(),

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -14,6 +14,7 @@ use crate::errors::{PrimaBridgeError, PrimaBridgeResult};
 use crate::{Bridge, Response};
 
 mod body;
+mod otel;
 mod request_type;
 
 pub enum RequestType {
@@ -248,14 +249,10 @@ pub trait DeliverableRequest<'a>: Sized + 'a {
 
     #[cfg(feature = "tracing_opentelemetry")]
     fn tracing_headers(&self) -> HeaderMap {
-        use opentelemetry::propagation::text_map_propagator::TextMapPropagator;
         use std::collections::HashMap;
-        use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-        let context = tracing::Span::current().context();
         let mut tracing_headers: HashMap<String, String> = HashMap::new();
-        let extractor = opentelemetry::sdk::propagation::TraceContextPropagator::new();
-        extractor.inject_context(&context, &mut tracing_headers);
+        otel::inject_context(&mut tracing_headers);
 
         tracing_headers
             .iter()

--- a/src/request/otel.rs
+++ b/src/request/otel.rs
@@ -1,0 +1,9 @@
+use opentelemetry::{
+    propagation::{Injector, TextMapPropagator},
+    sdk::propagation::TraceContextPropagator,
+};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+pub fn inject_context(injector: &mut dyn Injector) {
+    TraceContextPropagator::new().inject_context(&tracing::Span::current().context(), injector);
+}


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-1201

While this PR is mainly to allow OTEL 0.20, I took the opportunity to remove patches from our dependencies since I am on a crusade
