### PR TITLE
Remove old time dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ async-trait = "0.1.52"
 jsonwebtoken = { version = "8.0.1", optional = true }
 redis = { version = "0.23.0", features = ["tokio-comp"], optional = true }
 rand = { version = "0.8.4", optional = true }
-chrono = { version = "^0.4", features = ["serde"], optional = true }
-chrono-tz = { version = "^0.6", optional = true }
+chrono = { version = "0.4.26", default-features = false, features = ["clock", "std", "serde"], optional = true }
+chrono-tz = { version = "0.6.3", optional = true }
 aes = { version = "0.8.1", optional = true }
 cbc = { version = "0.1.2", features = ["std"], optional = true }
 dashmap = { version = "5.1.0", optional = true }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65
+FROM rust:1.67
 
 WORKDIR /code
 

--- a/src/auth0/mod.rs
+++ b/src/auth0/mod.rs
@@ -40,7 +40,7 @@ impl Auth0 {
         let jwks_lock: Arc<RwLock<JsonWebKeySet>> = Arc::new(RwLock::new(jwks));
         let token_lock: Arc<RwLock<Token>> = Arc::new(RwLock::new(token));
 
-        let _: JoinHandle<()> = start(
+        let _handle: JoinHandle<()> = start(
             jwks_lock.clone(),
             token_lock.clone(),
             client_ref.clone(),


### PR DESCRIPTION
`chrono@0.4.26` by default includes `time@0.1.x` that is affected by a potential [segmentation fault](https://github.com/primait/cashcade/security/dependabot/9) issue.

The `oldtime` feature is actually unused, so this PR removes it.