### PR TITLE
add pool_idle_timeout option to builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to
 
 ### Removed
 
-- Support for opentelemetry 0.20
+- Drop support for opentelemetry 0.20
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Support for the option `pool_idle_timeout` in the client builder
+
+### Removed
+
+- Support for opentelemetry 0.20
+
 ---
 
 ## [0.18.0] - 2024-10-22
@@ -145,7 +153,7 @@ mightremove support for older otel version without it being a breaking change.
 
 ### Changed
 
-- MSRV is 1.72, for https://github.com/rust-lang/rust/issues/107557
+- MSRV is 1.72, for <https://github.com/rust-lang/rust/issues/107557>
 
 ---
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,44 +13,90 @@ rust-version = "1.72"
 [features]
 default = ["tracing_opentelemetry"]
 
-auth0 = ["rand", "redis", "jsonwebtoken", "chrono", "chacha20poly1305", "dashmap", "tracing"]
+auth0 = [
+  "rand",
+  "redis",
+  "jsonwebtoken",
+  "chrono",
+  "chacha20poly1305",
+  "dashmap",
+  "tracing",
+]
 gzip = ["reqwest/gzip"]
 redis-tls = ["redis/tls", "redis/tokio-native-tls-comp"]
-tracing_opentelemetry = [ "tracing_opentelemetry_0_26" ]
+tracing_opentelemetry = ["tracing_opentelemetry_0_26"]
 
-tracing_opentelemetry_0_20 = ["_any_otel_version", "tracing", "tracing-opentelemetry_0_21_pkg", "opentelemetry_0_20_pkg"]
-tracing_opentelemetry_0_21 = ["_any_otel_version", "tracing", "tracing-opentelemetry_0_22_pkg", "opentelemetry_0_21_pkg", "opentelemetry_sdk_0_21_pkg"]
-tracing_opentelemetry_0_22 = ["_any_otel_version", "tracing", "tracing-opentelemetry_0_23_pkg", "opentelemetry_0_22_pkg", "opentelemetry_sdk_0_22_pkg"]
-tracing_opentelemetry_0_23 = ["_any_otel_version", "tracing", "tracing-opentelemetry_0_24_pkg", "opentelemetry_0_23_pkg", "opentelemetry_sdk_0_23_pkg"]
-tracing_opentelemetry_0_24 = ["_any_otel_version", "tracing", "tracing-opentelemetry_0_25_pkg", "opentelemetry_0_24_pkg", "opentelemetry_sdk_0_24_pkg"]
-tracing_opentelemetry_0_25 = ["_any_otel_version", "tracing", "tracing-opentelemetry_0_26_pkg", "opentelemetry_0_25_pkg", "opentelemetry_sdk_0_25_pkg"]
-tracing_opentelemetry_0_26 = ["_any_otel_version", "tracing", "tracing-opentelemetry_0_27_pkg", "opentelemetry_0_26_pkg", "opentelemetry_sdk_0_26_pkg"]
+tracing_opentelemetry_0_21 = [
+  "_any_otel_version",
+  "tracing",
+  "tracing-opentelemetry_0_22_pkg",
+  "opentelemetry_0_21_pkg",
+  "opentelemetry_sdk_0_21_pkg",
+]
+tracing_opentelemetry_0_22 = [
+  "_any_otel_version",
+  "tracing",
+  "tracing-opentelemetry_0_23_pkg",
+  "opentelemetry_0_22_pkg",
+  "opentelemetry_sdk_0_22_pkg",
+]
+tracing_opentelemetry_0_23 = [
+  "_any_otel_version",
+  "tracing",
+  "tracing-opentelemetry_0_24_pkg",
+  "opentelemetry_0_23_pkg",
+  "opentelemetry_sdk_0_23_pkg",
+]
+tracing_opentelemetry_0_24 = [
+  "_any_otel_version",
+  "tracing",
+  "tracing-opentelemetry_0_25_pkg",
+  "opentelemetry_0_24_pkg",
+  "opentelemetry_sdk_0_24_pkg",
+]
+tracing_opentelemetry_0_25 = [
+  "_any_otel_version",
+  "tracing",
+  "tracing-opentelemetry_0_26_pkg",
+  "opentelemetry_0_25_pkg",
+  "opentelemetry_sdk_0_25_pkg",
+]
+tracing_opentelemetry_0_26 = [
+  "_any_otel_version",
+  "tracing",
+  "tracing-opentelemetry_0_27_pkg",
+  "opentelemetry_0_26_pkg",
+  "opentelemetry_sdk_0_26_pkg",
+]
 
 _any_otel_version = []
 
 [dependencies]
 async-trait = "0.1"
 bytes = "1.2"
-chrono = {version = "0.4", default-features = false, features = ["clock", "std", "serde"], optional = true}
-dashmap = {version = "6.0", optional = true}
+chrono = { version = "0.4", default-features = false, features = [
+  "clock",
+  "std",
+  "serde",
+], optional = true }
+dashmap = { version = "6.0", optional = true }
 futures = "0.3"
 futures-util = "0.3"
-jsonwebtoken = {version = "9.0", optional = true}
-rand = {version = "0.8", optional = true}
-redis = {version = "0.27", features = ["tokio-comp"], optional = true}
-reqwest = {version = "0.12", features = ["json", "multipart", "stream"]}
-serde = {version = "1.0", features = ["derive"]}
+jsonwebtoken = { version = "9.0", optional = true }
+rand = { version = "0.8", optional = true }
+redis = { version = "0.27", features = ["tokio-comp"], optional = true }
+reqwest = { version = "0.12", features = ["json", "multipart", "stream"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = {version = "1.16", features = ["macros", "rt-multi-thread", "fs"]}
-tracing = {version = "0.1", optional = true}
-uuid = {version = ">=0.7.0, <2.0.0", features = ["serde", "v4"]}
+tokio = { version = "1.16", features = ["macros", "rt-multi-thread", "fs"] }
+tracing = { version = "0.1", optional = true }
+uuid = { version = ">=0.7.0, <2.0.0", features = ["serde", "v4"] }
 chacha20poly1305 = { version = "0.10.1", features = ["std"], optional = true }
 
 reqwest-middleware = { version = "0.3.0", features = ["json", "multipart"] }
 http = "1.0.0"
 
-opentelemetry_0_20_pkg = { package = "opentelemetry", version = "0.20", optional = true }
 opentelemetry_0_21_pkg = { package = "opentelemetry", version = "0.21", optional = true }
 opentelemetry_0_22_pkg = { package = "opentelemetry", version = "0.22", optional = true }
 opentelemetry_0_23_pkg = { package = "opentelemetry", version = "0.23", optional = true }
@@ -74,7 +120,7 @@ tracing-opentelemetry_0_27_pkg = { package = "tracing-opentelemetry", version = 
 [dev-dependencies]
 flate2 = "1.0"
 mockito = "1.0"
-tokio = {version = "1.16", features = ["macros", "rt-multi-thread"]}
+tokio = { version = "1.16", features = ["macros", "rt-multi-thread"] }
 tokio-test = "0.4"
 
 [profile.release]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,9 +7,9 @@ category = "Build"
 install_crate = false
 command = "cargo"
 args = [
-    "build",
-    "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)",
-    "@@split(CARGO_MAKE_CARGO_BUILD_TEST_FLAGS, )",
+  "build",
+  "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)",
+  "@@split(CARGO_MAKE_CARGO_BUILD_TEST_FLAGS, )",
 ]
 
 [tasks.fmt-check]
@@ -19,15 +19,14 @@ args = ["fmt", "--", "--check"]
 
 [tasks.test]
 dependencies = [
-    "test-base",
-    "test-auth0",
-    "test-otel-0_20",
-    "test-otel-0_21",
-    "test-otel-0_22",
-    "test-otel-0_23",
-    "test-otel-0_24",
-    "test-otel-0_25",
-    "test-otel-0_26"
+  "test-base",
+  "test-auth0",
+  "test-otel-0_21",
+  "test-otel-0_22",
+  "test-otel-0_23",
+  "test-otel-0_24",
+  "test-otel-0_25",
+  "test-otel-0_26",
 ]
 
 [tasks.test-base]
@@ -40,45 +39,71 @@ command = "cargo"
 args = ["test", "--features=auth0,gzip", "${@}"]
 dependencies = ["build"]
 
-[tasks.test-otel-0_20]
-command = "cargo"
-args = ["test", "--no-default-features", "--features", "tracing_opentelemetry_0_20"]
-
 [tasks.test-otel-0_21]
 command = "cargo"
-args = ["test", "--no-default-features", "--features", "tracing_opentelemetry_0_21"]
+args = [
+  "test",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_21",
+]
 
 [tasks.test-otel-0_22]
 command = "cargo"
-args = ["test", "--no-default-features", "--features", "tracing_opentelemetry_0_22"]
+args = [
+  "test",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_22",
+]
 
 [tasks.test-otel-0_23]
 command = "cargo"
-args = ["test", "--no-default-features", "--features", "tracing_opentelemetry_0_23"]
+args = [
+  "test",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_23",
+]
 
 [tasks.test-otel-0_24]
 command = "cargo"
-args = ["test", "--no-default-features", "--features", "tracing_opentelemetry_0_24"]
+args = [
+  "test",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_24",
+]
 
 [tasks.test-otel-0_25]
 command = "cargo"
-args = ["test", "--no-default-features", "--features", "tracing_opentelemetry_0_25"]
+args = [
+  "test",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_25",
+]
 
 [tasks.test-otel-0_26]
 command = "cargo"
-args = ["test", "--no-default-features", "--features", "tracing_opentelemetry_0_26"]
+args = [
+  "test",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_26",
+]
 
 [tasks.clippy]
 dependencies = [
-    "clippy-base",
-    "clippy-auth0",
-    "clippy-otel-0_20",
-    "clippy-otel-0_21",
-    "clippy-otel-0_22",
-    "clippy-otel-0_23",
-    "clippy-otel-0_24",
-    "clippy-otel-0_25",
-    "clippy-otel-0_26",
+  "clippy-base",
+  "clippy-auth0",
+  "clippy-otel-0_20",
+  "clippy-otel-0_21",
+  "clippy-otel-0_22",
+  "clippy-otel-0_23",
+  "clippy-otel-0_24",
+  "clippy-otel-0_25",
+  "clippy-otel-0_26",
 ]
 
 [tasks.clippy-base]
@@ -88,80 +113,181 @@ dependencies = ["build"]
 
 [tasks.clippy-auth0]
 command = "cargo"
-args = ["clippy", "--features=auth0,gzip", "--all-targets", "--", "-D", "warnings"]
+args = [
+  "clippy",
+  "--features=auth0,gzip",
+  "--all-targets",
+  "--",
+  "-D",
+  "warnings",
+]
 dependencies = ["build"]
 
 [tasks.clippy-otel-0_20]
 command = "cargo"
-args = ["clippy", "--no-default-features", "--features", "tracing_opentelemetry_0_20", "--all-targets", "--", "-D", "warnings"]
+args = [
+  "clippy",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_20",
+  "--all-targets",
+  "--",
+  "-D",
+  "warnings",
+]
 
 [tasks.clippy-otel-0_21]
 command = "cargo"
-args = ["clippy", "--no-default-features", "--features", "tracing_opentelemetry_0_21", "--all-targets", "--", "-D", "warnings"]
+args = [
+  "clippy",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_21",
+  "--all-targets",
+  "--",
+  "-D",
+  "warnings",
+]
 
 [tasks.clippy-otel-0_22]
 command = "cargo"
-args = ["clippy", "--no-default-features", "--features", "tracing_opentelemetry_0_22", "--all-targets", "--", "-D", "warnings"]
+args = [
+  "clippy",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_22",
+  "--all-targets",
+  "--",
+  "-D",
+  "warnings",
+]
 
 [tasks.clippy-otel-0_23]
 command = "cargo"
-args = ["clippy", "--no-default-features", "--features", "tracing_opentelemetry_0_23", "--all-targets", "--", "-D", "warnings"]
+args = [
+  "clippy",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_23",
+  "--all-targets",
+  "--",
+  "-D",
+  "warnings",
+]
 
 [tasks.clippy-otel-0_24]
 command = "cargo"
-args = ["clippy", "--no-default-features", "--features", "tracing_opentelemetry_0_24", "--all-targets", "--", "-D", "warnings"]
+args = [
+  "clippy",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_24",
+  "--all-targets",
+  "--",
+  "-D",
+  "warnings",
+]
 
 [tasks.clippy-otel-0_25]
 command = "cargo"
-args = ["clippy", "--no-default-features", "--features", "tracing_opentelemetry_0_25", "--all-targets", "--", "-D", "warnings"]
+args = [
+  "clippy",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_25",
+  "--all-targets",
+  "--",
+  "-D",
+  "warnings",
+]
 
 [tasks.clippy-otel-0_26]
 command = "cargo"
-args = ["clippy", "--no-default-features", "--features", "tracing_opentelemetry_0_26", "--all-targets", "--", "-D", "warnings"]
+args = [
+  "clippy",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_26",
+  "--all-targets",
+  "--",
+  "-D",
+  "warnings",
+]
 
 [tasks.deny-check]
 dependencies = [
-    "deny-check-otel-0_20",
-    "deny-check-otel-0_21",
-    "deny-check-otel-0_22",
-    "deny-check-otel-0_23",
-    "deny-check-otel-0_24",
-    "deny-check-otel-0_25",
-    "deny-check-otel-0_26",
+  "deny-check-otel-0_20",
+  "deny-check-otel-0_21",
+  "deny-check-otel-0_22",
+  "deny-check-otel-0_23",
+  "deny-check-otel-0_24",
+  "deny-check-otel-0_25",
+  "deny-check-otel-0_26",
 ]
 
-[tasks.deny-check-otel-0_20]
-args = ["deny", "--no-default-features", "--features", "tracing_opentelemetry_0_20", "check"]
-command = "cargo"
-description = "Run cargo-deny with tracing_opentelemetry_0_20 feature"
-
 [tasks.deny-check-otel-0_21]
-args = ["deny", "--no-default-features", "--features", "tracing_opentelemetry_0_21", "check"]
+args = [
+  "deny",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_21",
+  "check",
+]
 command = "cargo"
 description = "Run cargo-deny with tracing_opentelemetry_0_21 feature"
 
 [tasks.deny-check-otel-0_22]
-args = ["deny", "--no-default-features", "--features", "tracing_opentelemetry_0_22", "check"]
+args = [
+  "deny",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_22",
+  "check",
+]
 command = "cargo"
 description = "Run cargo-deny with tracing_opentelemetry_0_22 feature"
 
 [tasks.deny-check-otel-0_23]
-args = ["deny", "--no-default-features", "--features", "tracing_opentelemetry_0_23", "check"]
+args = [
+  "deny",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_23",
+  "check",
+]
 command = "cargo"
 description = "Run cargo-deny with tracing_opentelemetry_0_23 feature"
 
 [tasks.deny-check-otel-0_24]
-args = ["deny", "--no-default-features", "--features", "tracing_opentelemetry_0_24", "check"]
+args = [
+  "deny",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_24",
+  "check",
+]
 command = "cargo"
 description = "Run cargo-deny with tracing_opentelemetry_0_24 feature"
 
 [tasks.deny-check-otel-0_25]
-args = ["deny", "--no-default-features", "--features", "tracing_opentelemetry_0_25", "check"]
+args = [
+  "deny",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_25",
+  "check",
+]
 command = "cargo"
 description = "Run cargo-deny with tracing_opentelemetry_0_25 feature"
 
 [tasks.deny-check-otel-0_26]
-args = ["deny", "--no-default-features", "--features", "tracing_opentelemetry_0_26", "check"]
+args = [
+  "deny",
+  "--no-default-features",
+  "--features",
+  "tracing_opentelemetry_0_26",
+  "check",
+]
 command = "cargo"
 description = "Run cargo-deny with tracing_opentelemetry_0_26 feature"
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -97,7 +97,6 @@ args = [
 dependencies = [
   "clippy-base",
   "clippy-auth0",
-  "clippy-otel-0_20",
   "clippy-otel-0_21",
   "clippy-otel-0_22",
   "clippy-otel-0_23",
@@ -122,19 +121,6 @@ args = [
   "warnings",
 ]
 dependencies = ["build"]
-
-[tasks.clippy-otel-0_20]
-command = "cargo"
-args = [
-  "clippy",
-  "--no-default-features",
-  "--features",
-  "tracing_opentelemetry_0_20",
-  "--all-targets",
-  "--",
-  "-D",
-  "warnings",
-]
 
 [tasks.clippy-otel-0_21]
 command = "cargo"
@@ -216,7 +202,6 @@ args = [
 
 [tasks.deny-check]
 dependencies = [
-  "deny-check-otel-0_20",
   "deny-check-otel-0_21",
   "deny-check-otel-0_22",
   "deny-check-otel-0_23",

--- a/deny.toml
+++ b/deny.toml
@@ -2,22 +2,12 @@
 feature-depth = 1
 
 [licenses]
-allow = [
-    "Apache-2.0",
-    "BSD-3-Clause",
-    "MIT",
-    "ISC",
-    "Unicode-DFS-2016",
-    "Unicode-3.0",
-    "Zlib",
-]
+allow = ["Apache-2.0", "BSD-3-Clause", "MIT", "ISC", "Unicode-3.0", "Zlib"]
 
 [[licenses.clarify]]
 crate = "ring"
 expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
-]
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [licenses.private]
 ignore = true
@@ -28,12 +18,9 @@ wildcards = "allow"
 highlight = "all"
 workspace-default-features = "allow"
 external-default-features = "allow"
-deny = [
-    { crate = "opentelemetry", deny-multiple-versions = true }
-]
+deny = [{ crate = "opentelemetry", deny-multiple-versions = true }]
 
 [sources]
 unknown-registry = "warn"
 unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use reqwest::Url;
 use reqwest_middleware::Middleware;
@@ -61,6 +61,19 @@ impl BridgeBuilderInner<reqwest::ClientBuilder> {
     pub fn with_pool_max_idle_per_host(self, max: usize) -> Self {
         Self {
             inner: self.inner.pool_max_idle_per_host(max),
+            #[cfg(feature = "auth0")]
+            auth0: self.auth0,
+        }
+    }
+
+    /// Set an optional timeout for idle sockets being kept-alive.
+    ///
+    /// Pass `None` to disable timeout.
+    ///
+    /// Default is 90 seconds.
+    pub fn with_pool_idle_timeout(self, max: Option<Duration>) -> Self {
+        Self {
+            inner: self.inner.pool_idle_timeout(max),
             #[cfg(feature = "auth0")]
             auth0: self.auth0,
         }

--- a/src/request/otel.rs
+++ b/src/request/otel.rs
@@ -1,16 +1,3 @@
-#[cfg(feature = "tracing_opentelemetry_0_20")]
-mod otel_0_20 {
-    pub use opentelemetry_0_20_pkg::{
-        propagation::{Injector, TextMapPropagator},
-        sdk::propagation::TraceContextPropagator,
-    };
-    pub use tracing_opentelemetry_0_21_pkg::OpenTelemetrySpanExt;
-
-    pub fn inject_context(injector: &mut dyn Injector) {
-        TraceContextPropagator::new().inject_context(&tracing::Span::current().context(), injector);
-    }
-}
-
 #[cfg(feature = "tracing_opentelemetry_0_21")]
 mod otel_0_21 {
     pub use opentelemetry_0_21_pkg::propagation::{Injector, TextMapPropagator};
@@ -76,9 +63,6 @@ mod otel_0_26 {
         TraceContextPropagator::new().inject_context(&tracing::Span::current().context(), injector);
     }
 }
-
-#[cfg(feature = "tracing_opentelemetry_0_20")]
-pub use otel_0_20::inject_context;
 
 #[cfg(feature = "tracing_opentelemetry_0_21")]
 pub use otel_0_21::inject_context;


### PR DESCRIPTION
Hello, 

The aim of this PR is to add an option to the builder which is related to the reqwest::clientbuilder option with the same name `pool_idle_timeout` which should help us reduce the number of errors related to unexpected closure of requests to Braintree because the idle timeout is lower than the default in reqwest. 

Note: Updated also cargo.toml based on cargo-deny check outputs