### PR TITLE
[DEVEX-2497]: Prefix redis keys with microservice name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,20 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   lint:
-    # Avoid duplicate jobs on PR from a branch on the same repo
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,8 +37,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: test
       AWS_ENDPOINT_URL: http://localhost:4566
       AWS_REGION: eu-west-1
-    # Avoid duplicate jobs on PR from a branch on the same repo
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +46,7 @@ jobs:
       - run: cargo make test
 
   alls-green:
-    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
+    if: always()
     runs-on: ubuntu-latest
     needs:
       - lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+---
+
+## [0.24.0] - 2025-05-29
+
 ### Added
 
 - Redis cache keys now use a format of:
@@ -551,7 +555,9 @@ Request::rest(&bridge).send()
 
 The old API is still available but deprecated. It will be removed soon.
 
-[Unreleased]: https://github.com/primait/bridge.rs/compare/0.23.0...HEAD
+
+[Unreleased]: https://github.com/primait/bridge.rs/compare/0.24.0...HEAD
+[0.24.0]: https://github.com/primait/bridge.rs/compare/0.23.0...0.24.0
 [0.23.0]: https://github.com/primait/bridge.rs/compare/0.22.0...0.23.0
 [0.22.0]: https://github.com/primait/bridge.rs/compare/0.21.0...0.22.0
 [0.21.0]: https://github.com/primait/bridge.rs/compare/0.20.0...0.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,20 @@ and this project adheres to
 ### Added
 
 - Cache keys are now dependent on implementation (Redis, DynamoDB, InMemory)
-- Redis and DynamoDb cache keys now use a format of
-  `{service_name}:auth0rs_tokens:{client_id}:{token_version}:{audience}` i.e.
-  the microservice name using the bridge is prepended, this should help with
-  permission handling on the various cache backends
-- In memory cache now uses a format of
-  `inmem:{client_id}:{token_version}:{audience}` (starting from version 1)
-- `service_name` has been added as part of the `Config` and as an argument to
-  our `Cache` implementation
+  - Redis cache keys now use a format of
+    `{service_name}:auth0rs_tokens:{client_id}:{token_version}:{audience}` i.e.
+    the microservice name using the bridge is prepended, this should help with
+    permission handling on the various cache backends
+  - DynamoDb uses a format of
+    `auth0rs_tokens:{client_id}:{token_version}:{audience}` (starting from
+    version 1)
+  - In memory cache now uses a format of
+    `inmem:{client_id}:{token_version}:{audience}` (starting from version 1)
+
+### Changed
+
+- `CacheType::Redis` is now a struct which accepts a url and a prefix for keys
+  saved on Redis.
 
 ### Undeprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Redis cache keys now use a format of:
+  `{service_name}:auth0rs_tokens:{client_id}:{token_version}:{audience}` i.e.
+  the microservice name using the bridge is prepended, this should help with
+  permission handling on the various cache backends
+- `service_name` has been added as part of the `Config` and as an argument to
+  our `Cache` implementation
+
+### Undeprecated
+
+- `Auth0::new` is undeprecated again, since it provides a convenient way to
+  setup the client. We reserve the right to re-deprecate it in the future once
+  we settle on a nicer API
+
 ---
 
 ## [0.23.0] - 2025-03-24
@@ -34,12 +49,12 @@ and this project adheres to
 
 ### Breaking
 
-- Redis cache keys now use a format: `auth0rs_tokens:{client_id}:{token_version}:{audience}"`
-  (changed from `auth0rs_tokens:{caller}:{token_version}:{audience}"`)
+- Redis cache keys now use a format:
+  `auth0rs_tokens:{client_id}:{token_version}:{audience}"` (changed from
+  `auth0rs_tokens:{caller}:{token_version}:{audience}"`)
 
-  In a lot of cases these should be the same and you won't need to change anything
-
-
+  In a lot of cases these should be the same and you won't need to change
+  anything
 
 ---
 
@@ -48,7 +63,8 @@ and this project adheres to
 ### Added
 
 - Support for opentelemetry 0.27, now the default version.
-- Added gRPC injector to help passing opentelemetry tracing context when doing gRPC calls.
+- Added gRPC injector to help passing opentelemetry tracing context when doing
+  gRPC calls.
 
 ---
 
@@ -94,15 +110,20 @@ and this project adheres to
 
 - The library no longer validates tokens after recieving them from auth0
 
-This was unneccessary, already wasn't done in some code paths, and as a bonus let us remove a dependency.
+This was unneccessary, already wasn't done in some code paths, and as a bonus
+let us remove a dependency.
 
 ### Changed
 
-- When first creating the client if bridge.rs fails to decrypt a cached token a warning will be logged, and a new token will be fetched
+- When first creating the client if bridge.rs fails to decrypt a cached token a
+  warning will be logged, and a new token will be fetched
 
-This behavior matches what happens when a token is automatically refreshed during the applications runtime, and should help address issues that might come up in the future.
+This behavior matches what happens when a token is automatically refreshed
+during the applications runtime, and should help address issues that might come
+up in the future.
 
-- The cache key now contains a cache version, allowing its schema to be updated in the future
+- The cache key now contains a cache version, allowing its schema to be updated
+  in the future
 
 From now on cache keys will use the following format:
 
@@ -120,8 +141,9 @@ eg.
 
 - Switched to using XChaCha20Poly1305 for the redis token cache encryption.
 
-This addresses a few medium severity security issues with the tokens.
-Note that this means that this, and future versions of the library cannot be used at the same time as older versions.
+This addresses a few medium severity security issues with the tokens. Note that
+this means that this, and future versions of the library cannot be used at the
+same time as older versions.
 
 ---
 
@@ -528,9 +550,6 @@ Request::rest(&bridge).send()
 ```
 
 The old API is still available but deprecated. It will be removed soon.
-
-
-
 
 [Unreleased]: https://github.com/primait/bridge.rs/compare/0.23.0...HEAD
 [0.23.0]: https://github.com/primait/bridge.rs/compare/0.22.0...0.23.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to
   - Redis cache keys now use a format of
     `{service_name}:auth0rs_tokens:{client_id}:{token_version}:{audience}` i.e.
     the microservice name using the bridge is prepended, this should help with
-    permission handling on the various cache backends
+    permission handling
   - DynamoDb and InMemory use a format of
     `auth0rs_tokens:{client_id}:{token_version}:{audience}` (starting from
     version 1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,17 @@ and this project adheres to
 
 ---
 
-## [0.24.0] - 2025-05-29
+## [0.24.0] - 2025-05-30
 
 ### Added
 
-- Redis cache keys now use a format of:
+- Cache keys are now dependent on implementation (Redis, DynamoDB, InMemory)
+- Redis and DynamoDb cache keys now use a format of
   `{service_name}:auth0rs_tokens:{client_id}:{token_version}:{audience}` i.e.
   the microservice name using the bridge is prepended, this should help with
   permission handling on the various cache backends
+- In memory cache now uses a format of
+  `inmem:{client_id}:{token_version}:{audience}` (starting from version 1)
 - `service_name` has been added as part of the `Config` and as an argument to
   our `Cache` implementation
 
@@ -554,7 +557,6 @@ Request::rest(&bridge).send()
 ```
 
 The old API is still available but deprecated. It will be removed soon.
-
 
 [Unreleased]: https://github.com/primait/bridge.rs/compare/0.24.0...HEAD
 [0.24.0]: https://github.com/primait/bridge.rs/compare/0.23.0...0.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to
 
 - Cache keys are now dependent on implementation (Redis, DynamoDB, InMemory)
   - Redis cache keys now use a format of
-    `{service_name}:auth0rs_tokens:{client_id}:{token_version}:{audience}` i.e.
+    `{user_defined_prefix}:auth0rs_tokens:{client_id}:{token_version}:{audience}` i.e.
     the microservice name using the bridge is prepended, this should help with
     permission handling
   - DynamoDb and InMemory use a format of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ and this project adheres to
 
 - Cache keys are now dependent on implementation (Redis, DynamoDB, InMemory)
   - Redis cache keys now use a format of
-    `{user_defined_prefix}:auth0rs_tokens:{client_id}:{token_version}:{audience}` i.e.
-    the microservice name using the bridge is prepended, this should help with
-    permission handling
-  - DynamoDb and InMemory use a format of
+    `{user_defined_prefix}:auth0rs_tokens:{client_id}:{token_version}:{audience}`
+    i.e. the microservice name using the bridge is prepended, this should help
+    with permission handling
+  - DynamoDb uses a format of
     `auth0rs_tokens:{client_id}:{token_version}:{audience}`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,9 @@ and this project adheres to
     `{service_name}:auth0rs_tokens:{client_id}:{token_version}:{audience}` i.e.
     the microservice name using the bridge is prepended, this should help with
     permission handling on the various cache backends
-  - DynamoDb uses a format of
+  - DynamoDb and InMemory use a format of
     `auth0rs_tokens:{client_id}:{token_version}:{audience}` (starting from
     version 1)
-  - In memory cache now uses a format of
-    `inmem:{client_id}:{token_version}:{audience}` (starting from version 1)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,7 @@ and this project adheres to
     the microservice name using the bridge is prepended, this should help with
     permission handling
   - DynamoDb and InMemory use a format of
-    `auth0rs_tokens:{client_id}:{token_version}:{audience}` (starting from
-    version 1)
+    `auth0rs_tokens:{client_id}:{token_version}:{audience}`
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "prima_bridge"
 readme = "README.md"
 repository = "https://github.com/primait/bridge.rs"
-version = "0.23.0"
+version = "0.24.0"
 # See https://github.com/rust-lang/rust/issues/107557
 rust-version = "1.81"
 

--- a/src/auth0/cache/dynamodb.rs
+++ b/src/auth0/cache/dynamodb.rs
@@ -134,7 +134,7 @@ impl DynamoDBCache {
 #[async_trait::async_trait]
 impl Cache for DynamoDBCache {
     async fn get_token(&self, client_id: &str, aud: &str) -> Result<Option<Token>, CacheError> {
-        let key = self.token_key(client_id, aud);
+        let key = super::token_key(&self.service_name, client_id, aud);
         let Some(attrs) = self
             .client
             .get_item()
@@ -159,7 +159,7 @@ impl Cache for DynamoDBCache {
     }
 
     async fn put_token(&self, client_id: &str, aud: &str, token: &Token) -> Result<(), CacheError> {
-        let key = self.token_key(client_id, aud);
+        let key = super::token_key(&self.service_name, client_id, aud);
         let encoded = serde_json::to_string(token).unwrap();
         self.client
             .put_item()
@@ -175,10 +175,6 @@ impl Cache for DynamoDBCache {
             .map_err(|e| DynamoDBCacheError::Aws(Box::new(e)))?;
 
         Ok(())
-    }
-
-    fn service_name(&self) -> &str {
-        self.service_name.as_str()
     }
 }
 

--- a/src/auth0/cache/dynamodb.rs
+++ b/src/auth0/cache/dynamodb.rs
@@ -134,7 +134,7 @@ impl DynamoDBCache {
 #[async_trait::async_trait]
 impl Cache for DynamoDBCache {
     async fn get_token(&self, client_id: &str, aud: &str) -> Result<Option<Token>, CacheError> {
-        let key = super::token_key(&self.service_name, client_id, aud);
+        let key = token_key(&self.service_name, client_id, aud);
         let Some(attrs) = self
             .client
             .get_item()
@@ -159,7 +159,7 @@ impl Cache for DynamoDBCache {
     }
 
     async fn put_token(&self, client_id: &str, aud: &str, token: &Token) -> Result<(), CacheError> {
-        let key = super::token_key(&self.service_name, client_id, aud);
+        let key = token_key(&self.service_name, client_id, aud);
         let encoded = serde_json::to_string(token).unwrap();
         self.client
             .put_item()
@@ -176,6 +176,22 @@ impl Cache for DynamoDBCache {
 
         Ok(())
     }
+}
+
+const TOKEN_VERSION: &str = "2";
+
+// The microservice name should always be prefixed, in order to simplify permission handling
+// (permissions are usually given as "microservice:*")
+// This is tool-dependent and may change if we figure out this doesn't fit DynamoDB in the future
+fn token_key(service_name: &str, caller: &str, audience: &str) -> String {
+    format!(
+        "{}:{}:{}:{}:{}",
+        service_name,
+        super::TOKEN_PREFIX,
+        caller,
+        TOKEN_VERSION,
+        audience
+    )
 }
 
 #[cfg(test)]

--- a/src/auth0/cache/dynamodb.rs
+++ b/src/auth0/cache/dynamodb.rs
@@ -129,7 +129,7 @@ impl DynamoDBCache {
 #[async_trait::async_trait]
 impl Cache for DynamoDBCache {
     async fn get_token(&self, client_id: &str, aud: &str) -> Result<Option<Token>, CacheError> {
-        let key = super::token_key(client_id, aud);
+        let key = self.token_key(client_id, aud);
         let Some(attrs) = self
             .client
             .get_item()
@@ -154,7 +154,7 @@ impl Cache for DynamoDBCache {
     }
 
     async fn put_token(&self, client_id: &str, aud: &str, token: &Token) -> Result<(), CacheError> {
-        let key = super::token_key(client_id, aud);
+        let key = self.token_key(client_id, aud);
         let encoded = serde_json::to_string(token).unwrap();
         self.client
             .put_item()

--- a/src/auth0/cache/dynamodb.rs
+++ b/src/auth0/cache/dynamodb.rs
@@ -173,7 +173,7 @@ impl Cache for DynamoDBCache {
     }
 }
 
-const TOKEN_VERSION: &str = "1";
+const TOKEN_VERSION: &str = "2";
 
 // This is tool-dependent and may change if we figure out this doesn't fit DynamoDB in the future
 fn token_key(caller: &str, audience: &str) -> String {

--- a/src/auth0/cache/inmemory.rs
+++ b/src/auth0/cache/inmemory.rs
@@ -8,6 +8,16 @@ use super::CacheError;
 #[derive(Default, Clone, Debug)]
 pub struct InMemoryCache {
     key_value: DashMap<String, Token>,
+    service_name: String,
+}
+
+impl InMemoryCache {
+    pub fn new(service_name: String) -> Self {
+        Self {
+            key_value: DashMap::default(),
+            service_name,
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -23,6 +33,10 @@ impl Cache for InMemoryCache {
         let _ = self.key_value.insert(key, token.clone());
         Ok(())
     }
+
+    fn service_name(&self) -> &str {
+        self.service_name.as_str()
+    }
 }
 
 #[cfg(test)]
@@ -35,8 +49,9 @@ mod tests {
     async fn inmemory_cache_get_set_values() {
         let client_id = "caller".to_string();
         let audience = "audience".to_string();
+        let service = "service".to_string();
 
-        let cache = InMemoryCache::default();
+        let cache = InMemoryCache::new(service);
 
         let result: Option<Token> = cache.get_token(&client_id, &audience).await.unwrap();
         assert!(result.is_none());

--- a/src/auth0/cache/inmemory.rs
+++ b/src/auth0/cache/inmemory.rs
@@ -1,6 +1,5 @@
 use dashmap::DashMap;
 
-use crate::auth0::cache;
 use crate::auth0::cache::Cache;
 use crate::auth0::token::Token;
 
@@ -14,15 +13,13 @@ pub struct InMemoryCache {
 #[async_trait::async_trait]
 impl Cache for InMemoryCache {
     async fn get_token(&self, client_id: &str, aud: &str) -> Result<Option<Token>, CacheError> {
-        let token = self
-            .key_value
-            .get(&cache::token_key(client_id, aud))
-            .map(|v| v.to_owned());
+        let key = self.token_key(client_id, aud);
+        let token = self.key_value.get(key.as_str()).map(|v| v.to_owned());
         Ok(token)
     }
 
     async fn put_token(&self, client_id: &str, aud: &str, token: &Token) -> Result<(), CacheError> {
-        let key: String = cache::token_key(client_id, aud);
+        let key: String = self.token_key(client_id, aud);
         let _ = self.key_value.insert(key, token.clone());
         Ok(())
     }

--- a/src/auth0/cache/inmemory.rs
+++ b/src/auth0/cache/inmemory.rs
@@ -23,19 +23,15 @@ impl InMemoryCache {
 #[async_trait::async_trait]
 impl Cache for InMemoryCache {
     async fn get_token(&self, client_id: &str, aud: &str) -> Result<Option<Token>, CacheError> {
-        let key = self.token_key(client_id, aud);
+        let key = super::token_key(&self.service_name, client_id, aud);
         let token = self.key_value.get(key.as_str()).map(|v| v.to_owned());
         Ok(token)
     }
 
     async fn put_token(&self, client_id: &str, aud: &str, token: &Token) -> Result<(), CacheError> {
-        let key: String = self.token_key(client_id, aud);
+        let key = super::token_key(&self.service_name, client_id, aud);
         let _ = self.key_value.insert(key, token.clone());
         Ok(())
-    }
-
-    fn service_name(&self) -> &str {
-        self.service_name.as_str()
     }
 }
 

--- a/src/auth0/cache/inmemory.rs
+++ b/src/auth0/cache/inmemory.rs
@@ -5,7 +5,7 @@ use crate::auth0::token::Token;
 
 use super::CacheError;
 
-const TOKEN_VERSION: &str = "1";
+const TOKEN_VERSION: &str = "2";
 
 #[derive(Default, Clone, Debug)]
 pub struct InMemoryCache {

--- a/src/auth0/cache/inmemory.rs
+++ b/src/auth0/cache/inmemory.rs
@@ -28,7 +28,7 @@ impl Cache for InMemoryCache {
 }
 
 fn token_key(client_id: &str, audience: &str) -> String {
-    format!("inmem:v{}:{}:{}", TOKEN_VERSION, client_id, audience)
+    format!("inmem:{}:{}:{}", client_id, TOKEN_VERSION, audience)
 }
 
 #[cfg(test)]
@@ -41,7 +41,6 @@ mod tests {
     async fn inmemory_cache_get_set_values() {
         let client_id = "caller".to_string();
         let audience = "audience".to_string();
-        let service = "service".to_string();
 
         let cache = InMemoryCache::default();
 

--- a/src/auth0/cache/inmemory.rs
+++ b/src/auth0/cache/inmemory.rs
@@ -8,31 +8,25 @@ use super::CacheError;
 #[derive(Default, Clone, Debug)]
 pub struct InMemoryCache {
     key_value: DashMap<String, Token>,
-    service_name: String,
-}
-
-impl InMemoryCache {
-    pub fn new(service_name: String) -> Self {
-        Self {
-            key_value: DashMap::default(),
-            service_name,
-        }
-    }
 }
 
 #[async_trait::async_trait]
 impl Cache for InMemoryCache {
     async fn get_token(&self, client_id: &str, aud: &str) -> Result<Option<Token>, CacheError> {
-        let key = super::token_key(&self.service_name, client_id, aud);
+        let key = token_key(client_id, aud);
         let token = self.key_value.get(key.as_str()).map(|v| v.to_owned());
         Ok(token)
     }
 
     async fn put_token(&self, client_id: &str, aud: &str, token: &Token) -> Result<(), CacheError> {
-        let key = super::token_key(&self.service_name, client_id, aud);
+        let key = token_key(client_id, aud);
         let _ = self.key_value.insert(key, token.clone());
         Ok(())
     }
+}
+
+fn token_key(client_id: &str, audience: &str) -> String {
+    format!("{}:{}", client_id, audience)
 }
 
 #[cfg(test)]
@@ -47,7 +41,7 @@ mod tests {
         let audience = "audience".to_string();
         let service = "service".to_string();
 
-        let cache = InMemoryCache::new(service);
+        let cache = InMemoryCache::default();
 
         let result: Option<Token> = cache.get_token(&client_id, &audience).await.unwrap();
         assert!(result.is_none());

--- a/src/auth0/cache/inmemory.rs
+++ b/src/auth0/cache/inmemory.rs
@@ -28,7 +28,7 @@ impl Cache for InMemoryCache {
 }
 
 fn token_key(client_id: &str, audience: &str) -> String {
-    format!("inmem:{}:{}:{}", client_id, TOKEN_VERSION, audience)
+    format!("{}:{}:{}:{}", super::TOKEN_PREFIX, client_id, TOKEN_VERSION, audience)
 }
 
 #[cfg(test)]

--- a/src/auth0/cache/inmemory.rs
+++ b/src/auth0/cache/inmemory.rs
@@ -5,6 +5,8 @@ use crate::auth0::token::Token;
 
 use super::CacheError;
 
+const TOKEN_VERSION: &str = "1";
+
 #[derive(Default, Clone, Debug)]
 pub struct InMemoryCache {
     key_value: DashMap<String, Token>,
@@ -26,7 +28,7 @@ impl Cache for InMemoryCache {
 }
 
 fn token_key(client_id: &str, audience: &str) -> String {
-    format!("{}:{}", client_id, audience)
+    format!("inmem:v{}:{}:{}", TOKEN_VERSION, client_id, audience)
 }
 
 #[cfg(test)]

--- a/src/auth0/cache/mod.rs
+++ b/src/auth0/cache/mod.rs
@@ -32,6 +32,8 @@ pub trait Cache: Send + Sync + std::fmt::Debug {
 
     fn service_name(&self) -> &str;
 
+    // The microservice name should always be prefixed, in order to simplify permission handling on
+    // tools such as Redis/DynamoDB/... (permissions are usually given as "microservice:*")
     fn token_key(&self, caller: &str, audience: &str) -> String {
         format!(
             "{}:{}:{}:{}:{}",

--- a/src/auth0/cache/mod.rs
+++ b/src/auth0/cache/mod.rs
@@ -29,19 +29,13 @@ pub trait Cache: Send + Sync + std::fmt::Debug {
     async fn get_token(&self, client_id: &str, aud: &str) -> Result<Option<Token>, CacheError>;
 
     async fn put_token(&self, client_id: &str, aud: &str, token: &Token) -> Result<(), CacheError>;
+}
 
-    fn service_name(&self) -> &str;
-
-    // The microservice name should always be prefixed, in order to simplify permission handling on
-    // tools such as Redis/DynamoDB/... (permissions are usually given as "microservice:*")
-    fn token_key(&self, caller: &str, audience: &str) -> String {
-        format!(
-            "{}:{}:{}:{}:{}",
-            self.service_name(),
-            TOKEN_PREFIX,
-            caller,
-            TOKEN_VERSION,
-            audience
-        )
-    }
+// The microservice name should always be prefixed, in order to simplify permission handling on
+// tools such as Redis/DynamoDB/... (permissions are usually given as "microservice:*")
+pub(in crate::auth0::cache) fn token_key(service_name: &str, caller: &str, audience: &str) -> String {
+    format!(
+        "{}:{}:{}:{}:{}",
+        service_name, TOKEN_PREFIX, caller, TOKEN_VERSION, audience
+    )
 }

--- a/src/auth0/cache/mod.rs
+++ b/src/auth0/cache/mod.rs
@@ -17,8 +17,6 @@ pub mod inmemory;
 pub mod redis_impl;
 
 const TOKEN_PREFIX: &str = "auth0rs_tokens";
-// The version of the token for backwards incompatible changes
-const TOKEN_VERSION: &str = "2";
 
 #[derive(thiserror::Error, Debug)]
 #[error(transparent)]
@@ -29,13 +27,4 @@ pub trait Cache: Send + Sync + std::fmt::Debug {
     async fn get_token(&self, client_id: &str, aud: &str) -> Result<Option<Token>, CacheError>;
 
     async fn put_token(&self, client_id: &str, aud: &str, token: &Token) -> Result<(), CacheError>;
-}
-
-// The microservice name should always be prefixed, in order to simplify permission handling on
-// tools such as Redis/DynamoDB/... (permissions are usually given as "microservice:*")
-pub(in crate::auth0::cache) fn token_key(service_name: &str, caller: &str, audience: &str) -> String {
-    format!(
-        "{}:{}:{}:{}:{}",
-        service_name, TOKEN_PREFIX, caller, TOKEN_VERSION, audience
-    )
 }

--- a/src/auth0/cache/mod.rs
+++ b/src/auth0/cache/mod.rs
@@ -29,8 +29,17 @@ pub trait Cache: Send + Sync + std::fmt::Debug {
     async fn get_token(&self, client_id: &str, aud: &str) -> Result<Option<Token>, CacheError>;
 
     async fn put_token(&self, client_id: &str, aud: &str, token: &Token) -> Result<(), CacheError>;
-}
 
-pub(in crate::auth0::cache) fn token_key(caller: &str, audience: &str) -> String {
-    format!("{}:{}:{}:{}", TOKEN_PREFIX, caller, TOKEN_VERSION, audience)
+    fn service_name(&self) -> &str;
+
+    fn token_key(&self, caller: &str, audience: &str) -> String {
+        format!(
+            "{}:{}:{}:{}:{}",
+            self.service_name(),
+            TOKEN_PREFIX,
+            caller,
+            TOKEN_VERSION,
+            audience
+        )
+    }
 }

--- a/src/auth0/cache/redis_impl.rs
+++ b/src/auth0/cache/redis_impl.rs
@@ -32,7 +32,7 @@ impl RedisCache {
     /// Redis connection string(eg. `"redis://{host}:{port}?{ParamKey1}={ParamKey2}"`)
     pub async fn new(
         redis_connection_url: String,
-        key_prefix: String,
+        redis_key_prefix: String,
         token_encryption_key: String,
     ) -> Result<Self, RedisCacheError> {
         let client: redis::Client = redis::Client::open(redis_connection_url)?;
@@ -42,7 +42,7 @@ impl RedisCache {
         Ok(RedisCache {
             client,
             encryption_key: token_encryption_key,
-            key_prefix,
+            key_prefix: redis_key_prefix,
         })
     }
 

--- a/src/auth0/cache/redis_impl.rs
+++ b/src/auth0/cache/redis_impl.rs
@@ -25,11 +25,16 @@ impl From<RedisCacheError> for super::CacheError {
 pub struct RedisCache {
     client: redis::Client,
     encryption_key: String,
+    service_name: String,
 }
 
 impl RedisCache {
     /// Redis connection string(eg. `"redis://{host}:{port}?{ParamKey1}={ParamKey2}"`)
-    pub async fn new(redis_connection_url: String, token_encryption_key: String) -> Result<Self, RedisCacheError> {
+    pub async fn new(
+        redis_connection_url: String,
+        service_name: String,
+        token_encryption_key: String,
+    ) -> Result<Self, RedisCacheError> {
         let client: redis::Client = redis::Client::open(redis_connection_url)?;
         // Ensure connection is fine. Should fail otherwise
         let _ = client.get_multiplexed_async_connection().await?;
@@ -37,6 +42,7 @@ impl RedisCache {
         Ok(RedisCache {
             client,
             encryption_key: token_encryption_key,
+            service_name,
         })
     }
 
@@ -75,6 +81,10 @@ impl Cache for RedisCache {
         self.put(key, value_ref.lifetime_in_seconds(), value_ref)
             .await
             .map_err(Into::into)
+    }
+
+    fn service_name(&self) -> &str {
+        self.service_name.as_str()
     }
 }
 

--- a/src/auth0/cache/redis_impl.rs
+++ b/src/auth0/cache/redis_impl.rs
@@ -72,19 +72,15 @@ impl RedisCache {
 #[async_trait::async_trait]
 impl Cache for RedisCache {
     async fn get_token(&self, client_id: &str, audience: &str) -> Result<Option<Token>, CacheError> {
-        let key = self.token_key(client_id, audience);
+        let key = super::token_key(&self.service_name, client_id, audience);
         self.get(key).await.map_err(Into::into)
     }
 
     async fn put_token(&self, client_id: &str, audience: &str, value_ref: &Token) -> Result<(), CacheError> {
-        let key = self.token_key(client_id, audience);
+        let key = super::token_key(&self.service_name, client_id, audience);
         self.put(key, value_ref.lifetime_in_seconds(), value_ref)
             .await
             .map_err(Into::into)
-    }
-
-    fn service_name(&self) -> &str {
-        self.service_name.as_str()
     }
 }
 

--- a/src/auth0/cache/redis_impl.rs
+++ b/src/auth0/cache/redis_impl.rs
@@ -86,7 +86,7 @@ impl Cache for RedisCache {
 
 const TOKEN_VERSION: &str = "2";
 
-// The microservice name should always be redis_key_prefixed, in order to simplify permission handling
+// The microservice name should always be prefixed, in order to simplify permission handling
 // (permissions are usually given as "microservice:*")
 // This is tool-dependent and may change if we figure out this doesn't fit Redis in the future
 fn token_key(key_prefix: &str, caller: &str, audience: &str) -> String {

--- a/src/auth0/config.rs
+++ b/src/auth0/config.rs
@@ -33,9 +33,6 @@ pub struct Config {
     /// Scope
     /// This is the scopes requested by the bridge when fetching tokens
     pub scope: Option<String>,
-    /// Service Name
-    /// This is the service name that is making the calls with the bridge
-    pub service_name: String,
 }
 
 impl Config {
@@ -83,10 +80,6 @@ impl Config {
         self.cache_type == CacheType::Inmemory
     }
 
-    pub fn service_name(&self) -> &str {
-        &self.service_name
-    }
-
     #[cfg(test)]
     pub fn test_config(server: &mockito::Server) -> Config {
         use std::str::FromStr;
@@ -102,7 +95,6 @@ impl Config {
             client_id: "client_id".to_string(),
             client_secret: "client_secret".to_string(),
             scope: None,
-            service_name: "service_name".to_string(),
         }
     }
 }
@@ -110,16 +102,25 @@ impl Config {
 // Eg. `Redis("redis://{host}:{port}?{ParamKey1}={ParamKey2}")` or `Inmemory` for inmemory cache
 #[derive(Clone, Eq, PartialEq)]
 pub enum CacheType {
-    Redis(String),
+    Redis { url: String, key_prefix: String },
     Inmemory,
 }
 
 impl CacheType {
     pub fn redis_connection_url(&self) -> &str {
         match &self {
-            CacheType::Redis(url) => url,
+            CacheType::Redis { url, .. } => url,
             CacheType::Inmemory => {
-                panic!("Something went wrong getting Redis connection string")
+                panic!("Cache type is set to Inmemory, you need to use Redis")
+            }
+        }
+    }
+
+    pub fn redis_key_prefix(&self) -> &str {
+        match &self {
+            CacheType::Redis { key_prefix, .. } => key_prefix,
+            CacheType::Inmemory => {
+                panic!("Cache type is set to Inmemory, you need to use Redis")
             }
         }
     }

--- a/src/auth0/config.rs
+++ b/src/auth0/config.rs
@@ -33,6 +33,9 @@ pub struct Config {
     /// Scope
     /// This is the scopes requested by the bridge when fetching tokens
     pub scope: Option<String>,
+    /// Service Name
+    /// This is the service name that is making the calls with the bridge
+    pub service_name: String,
 }
 
 impl Config {
@@ -80,6 +83,10 @@ impl Config {
         self.cache_type == CacheType::Inmemory
     }
 
+    pub fn service_name(&self) -> &str {
+        &self.service_name
+    }
+
     #[cfg(test)]
     pub fn test_config(server: &mockito::Server) -> Config {
         use std::str::FromStr;
@@ -95,6 +102,7 @@ impl Config {
             client_id: "client_id".to_string(),
             client_secret: "client_secret".to_string(),
             scope: None,
+            service_name: "service_name".to_string(),
         }
     }
 }

--- a/src/auth0/mod.rs
+++ b/src/auth0/mod.rs
@@ -27,10 +27,10 @@ impl Auth0 {
             Box::new(cache::InMemoryCache::default())
         } else {
             let redis_conn = config.cache_type().redis_connection_url().to_string();
+            let redis_key_prefix = config.cache_type().redis_key_prefix().to_string();
             let encryption_key = config.token_encryption_key().to_string();
-            let service_name = config.service_name().to_string();
             Box::new(
-                cache::RedisCache::new(redis_conn, service_name, encryption_key)
+                cache::RedisCache::new(redis_conn, redis_key_prefix, encryption_key)
                     .await
                     .map_err(Into::<CacheError>::into)?,
             )

--- a/src/auth0/mod.rs
+++ b/src/auth0/mod.rs
@@ -29,8 +29,9 @@ impl Auth0 {
         } else {
             let redis_conn = config.cache_type().redis_connection_url().to_string();
             let encryption_key = config.token_encryption_key().to_string();
+            let service_name = config.service_name().to_string();
             Box::new(
-                cache::RedisCache::new(redis_conn, encryption_key)
+                cache::RedisCache::new(redis_conn, service_name, encryption_key)
                     .await
                     .map_err(Into::<CacheError>::into)?,
             )

--- a/src/auth0/mod.rs
+++ b/src/auth0/mod.rs
@@ -22,7 +22,6 @@ pub use util::StalenessCheckPercentage;
 pub struct Auth0(RefreshingToken);
 
 impl Auth0 {
-    #[deprecated(since = "0.21.0", note = "please use refreshing token")]
     pub async fn new(client: &Client, config: Config) -> Result<Self, Auth0Error> {
         let cache: Box<dyn Cache> = if config.is_inmemory_cache() {
             Box::new(cache::InMemoryCache::default())


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/DEVEX-2497

This PR tries to address [this bug](https://prima-assicurazioni-spa.myjetbrains.com/youtrack/agiles/95-87/current?tab=columns-and%20swimlanes&issue=DEVEX-2605) which people are ecountering when migrating to the new library.

In [this discussion](https://prima.slack.com/archives/C01C70U9F37/p1740987674997099) it became clear that we needed a better key name for our tokens because of the way permissions are granted to microservices, so we decided to always prefix it with the microservice name.

This PR should implement that

