### PR TITLE
chore: pin rust 1.89 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain install 1.81.0
+      - run: rustup default 1.81.0
+      - run: rustup component add clippy rustfmt
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # ratchet:Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@ae532dedd825648efd18d9c49c9a443d0398ca0a # ratchet:taiki-e/install-action@cargo-make
       - uses: taiki-e/install-action@b98f5bfc2edc235d74c94cb39bd9d8cdd69dbbdf # ratchet:taiki-e/install-action@cargo-deny
@@ -40,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain install 1.81.0
+      - run: rustup default 1.81.0
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # ratchet:Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@ae532dedd825648efd18d9c49c9a443d0398ca0a # ratchet:taiki-e/install-action@cargo-make
       - run: cargo make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup default 1.81.0
+      - run: rustup default 1.82.0
       - run: rustup component add clippy rustfmt
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # ratchet:Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@ae532dedd825648efd18d9c49c9a443d0398ca0a # ratchet:taiki-e/install-action@cargo-make
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup default 1.81.0
+      - run: rustup default 1.82.0
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # ratchet:Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@ae532dedd825648efd18d9c49c9a443d0398ca0a # ratchet:taiki-e/install-action@cargo-make
       - run: cargo make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup default 1.86.0
+      - run: rustup default 1.89.0
       - run: rustup component add clippy rustfmt
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # ratchet:Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@ae532dedd825648efd18d9c49c9a443d0398ca0a # ratchet:taiki-e/install-action@cargo-make
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup default 1.86.0
+      - run: rustup default 1.89.0
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # ratchet:Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@ae532dedd825648efd18d9c49c9a443d0398ca0a # ratchet:taiki-e/install-action@cargo-make
       - run: cargo make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup default 1.82.0
+      - run: rustup default 1.86.0
       - run: rustup component add clippy rustfmt
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # ratchet:Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@ae532dedd825648efd18d9c49c9a443d0398ca0a # ratchet:taiki-e/install-action@cargo-make
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup default 1.82.0
+      - run: rustup default 1.86.0
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # ratchet:Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@ae532dedd825648efd18d9c49c9a443d0398ca0a # ratchet:taiki-e/install-action@cargo-make
       - run: cargo make test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/primait/bridge.rs"
 version = "0.25.0"
 # See https://github.com/rust-lang/rust/issues/107557
-rust-version = "1.82"
+rust-version = "1.86"
 
 [features]
 default = ["tracing_opentelemetry"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/primait/bridge.rs"
 version = "0.25.0"
 # See https://github.com/rust-lang/rust/issues/107557
-rust-version = "1.86"
+rust-version = "1.89"
 
 [features]
 default = ["tracing_opentelemetry"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ name = "prima_bridge"
 readme = "README.md"
 repository = "https://github.com/primait/bridge.rs"
 version = "0.25.0"
-# See https://github.com/rust-lang/rust/issues/107557
 rust-version = "1.89"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/primait/bridge.rs"
 version = "0.25.0"
 # See https://github.com/rust-lang/rust/issues/107557
-rust-version = "1.81"
+rust-version = "1.82"
 
 [features]
 default = ["tracing_opentelemetry"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86
+FROM rust:1.89
 
 WORKDIR /code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.81
+FROM rust:1.82
 
 WORKDIR /code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82
+FROM rust:1.86
 
 WORKDIR /code
 


### PR DESCRIPTION
Currently we run `rustup toolchain install 1.81.0` in our [ci.yml](https://github.com/primait/bridge.rs/blob/f46472a30e8cbb059d0197b2e7f7b775a71b32f2/.github/workflows/ci.yml#L21) which does add the specified rust version to the available toolchains, but doesn't make it the active one.
As a result we are using the default rustup toolchain which is the current stable version (see the logs [here](https://github.com/primait/bridge.rs/actions/runs/17823967547/job/50672716146)):

```
$ rustup show
Default host: x86_64-unknown-linux-gnu
rustup home:  /home/runner/.rustup

installed toolchains
--------------------
stable-x86_64-unknown-linux-gnu (active, default)
1.81.0-x86_64-unknown-linux-gnu

active toolchain
----------------
name: stable-x86_64-unknown-linux-gnu
active because: it's the default toolchain
installed targets:
  x86_64-unknown-linux-gnu
```

Rust [1.81](https://github.com/primait/bridge.rs/actions/runs/17824189557/job/50673393105) and [1.82](https://github.com/primait/bridge.rs/actions/runs/17824304593/job/50673747839) don't work anymore out of the box, the first version that compiles is `1.86`, but at this point I don't see any reason not to bump to the current stable since it's what we are already using anyway.