### PR TITLE
feat: add OpenTelemetry 0.32 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Support for OpenTelemetry 0.32 via the `tracing_opentelemetry_0_32` feature
+  (opentelemetry 0.32, opentelemetry_sdk 0.32, tracing-opentelemetry 0.33). The
+  default `tracing_opentelemetry` feature now targets 0.32.
+
 ---
 
 ## [0.30.0] - 2026-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+---
+
+## [0.31.0] - 2026-07-20
+
 ### Added
 
 - Support for OpenTelemetry 0.32 via the `tracing_opentelemetry_0_32` feature
@@ -632,7 +636,9 @@ Request::rest(&bridge).send()
 The old API is still available but deprecated. It will be removed soon.
 
 
-[Unreleased]: https://github.com/primait/bridge.rs/compare/0.30.0...HEAD
+
+[Unreleased]: https://github.com/primait/bridge.rs/compare/0.31.0...HEAD
+[0.31.0]: https://github.com/primait/bridge.rs/compare/0.30.0...0.31.0
 [0.30.0]: https://github.com/primait/bridge.rs/compare/0.29.0...0.30.0
 [0.29.0]: https://github.com/primait/bridge.rs/compare/0.28.0...0.29.0
 [0.28.0]: https://github.com/primait/bridge.rs/compare/0.27.0...0.28.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,6 +2057,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "opentelemetry_sdk"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,6 +2115,22 @@ dependencies = [
  "futures-util",
  "opentelemetry 0.31.0",
  "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
  "rand 0.9.2",
  "thiserror 2.0.18",
 ]
@@ -2254,6 +2284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,9 +2343,11 @@ dependencies = [
  "opentelemetry 0.29.1",
  "opentelemetry 0.30.0",
  "opentelemetry 0.31.0",
+ "opentelemetry 0.32.0",
  "opentelemetry_sdk 0.29.0",
  "opentelemetry_sdk 0.30.0",
  "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk 0.32.1",
  "rand 0.10.2",
  "redis",
  "reqwest",
@@ -2324,6 +2362,7 @@ dependencies = [
  "tracing-opentelemetry 0.30.0",
  "tracing-opentelemetry 0.31.0",
  "tracing-opentelemetry 0.32.1",
+ "tracing-opentelemetry 0.33.0",
  "uuid",
 ]
 
@@ -3514,6 +3553,22 @@ checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
  "opentelemetry 0.31.0",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.32.0",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "prima_bridge"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "prima_bridge"
 readme = "README.md"
 repository = "https://github.com/primait/bridge.rs"
-version = "0.30.0"
+version = "0.31.0"
 rust-version = "1.91"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ gzip = ["reqwest/gzip"]
 redis-tls = ["redis", "redis/tls", "redis/tokio-native-tls-comp"]
 cache-dynamodb = ["aws-sdk-dynamodb"]
 
-tracing_opentelemetry = ["tracing_opentelemetry_0_31"]
+tracing_opentelemetry = ["tracing_opentelemetry_0_32"]
 
 tracing_opentelemetry_0_29 = [
   "_any_otel_version",
@@ -60,6 +60,13 @@ tracing_opentelemetry_0_31 = [
   "tracing-opentelemetry_0_32_pkg",
   "opentelemetry_0_31_pkg",
   "opentelemetry_sdk_0_31_pkg",
+]
+tracing_opentelemetry_0_32 = [
+  "_any_otel_version",
+  "tracing",
+  "tracing-opentelemetry_0_33_pkg",
+  "opentelemetry_0_32_pkg",
+  "opentelemetry_sdk_0_32_pkg",
 ]
 
 _any_otel_version = []
@@ -97,12 +104,15 @@ http = "1.4.1"
 opentelemetry_0_29_pkg = { package = "opentelemetry", version = "0.29", optional = true }
 opentelemetry_0_30_pkg = { package = "opentelemetry", version = "0.30", optional = true }
 opentelemetry_0_31_pkg = { package = "opentelemetry", version = "0.31", optional = true }
+opentelemetry_0_32_pkg = { package = "opentelemetry", version = "0.32", optional = true }
 opentelemetry_sdk_0_29_pkg = { package = "opentelemetry_sdk", version = "0.29", optional = true }
 opentelemetry_sdk_0_30_pkg = { package = "opentelemetry_sdk", version = "0.30", optional = true }
 opentelemetry_sdk_0_31_pkg = { package = "opentelemetry_sdk", version = "0.31", optional = true }
+opentelemetry_sdk_0_32_pkg = { package = "opentelemetry_sdk", version = "0.32", optional = true }
 tracing-opentelemetry_0_30_pkg = { package = "tracing-opentelemetry", version = "0.30", optional = true }
 tracing-opentelemetry_0_31_pkg = { package = "tracing-opentelemetry", version = "0.31", optional = true }
 tracing-opentelemetry_0_32_pkg = { package = "tracing-opentelemetry", version = "0.32", optional = true }
+tracing-opentelemetry_0_33_pkg = { package = "tracing-opentelemetry", version = "0.33", optional = true }
 
 [dev-dependencies]
 aws-config = { version = "1.8", features = ["behavior-version-latest"] }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -6,6 +6,7 @@ AVAILABLE_OTEL_FEATURES = [
   "tracing_opentelemetry_0_29",
   "tracing_opentelemetry_0_30",
   "tracing_opentelemetry_0_31",
+  "tracing_opentelemetry_0_32",
 ]
 
 [tasks.build]

--- a/src/request/otel.rs
+++ b/src/request/otel.rs
@@ -19,6 +19,13 @@ pub(crate) mod otel_crates {
     pub use tracing_opentelemetry_0_32_pkg as tracing_opentelemetry;
 }
 
+#[cfg(feature = "tracing_opentelemetry_0_32")]
+pub(crate) mod otel_crates {
+    pub use opentelemetry_0_32_pkg as opentelemetry;
+    pub use opentelemetry_sdk_0_32_pkg as opentelemetry_sdk;
+    pub use tracing_opentelemetry_0_33_pkg as tracing_opentelemetry;
+}
+
 use otel_crates::*;
 
 pub use opentelemetry::propagation::Injector;


### PR DESCRIPTION
## What

Adds OpenTelemetry 0.32 support via a new `tracing_opentelemetry_0_32` feature,
following the existing per-version feature pattern:

| Crate | Version |
|-------|---------|
| `opentelemetry` | 0.32 |
| `opentelemetry_sdk` | 0.32 |
| `tracing-opentelemetry` | 0.33 |

The default `tracing_opentelemetry` feature now targets 0.32 (previously 0.31).

## Changes

- `Cargo.toml`: add `opentelemetry_0_32_pkg`, `opentelemetry_sdk_0_32_pkg`,
  `tracing-opentelemetry_0_33_pkg` optional deps; add the
  `tracing_opentelemetry_0_32` feature; bump the default alias to it.
- `src/request/otel.rs`: add the matching `#[cfg(feature = "tracing_opentelemetry_0_32")]`
  `otel_crates` re-export block.
- `Makefile.toml`: add `tracing_opentelemetry_0_32` to `AVAILABLE_OTEL_FEATURES`
  so the test / clippy / deny matrices cover it.
- `CHANGELOG.md`: Unreleased entry.
- `Cargo.lock`: regenerated.

## Why

`prima-tracing 0.25.0` already supports OpenTelemetry 0.32, so `prima_bridge`
should be extended to support it too and stay aligned across the tracing stack.

Otherwise, a service on otel 0.32 that also uses `prima_bridge` ends up with a
dual otel-version tree (0.31 via prima_bridge's default feature + 0.32 from the
app), which risks silently breaking trace-context propagation on outgoing HTTP
requests.

## Verification (local)

Run per the CI otel matrix with the new feature:

- `cargo check --no-default-features --features tracing_opentelemetry_0_32` -> clean
- `cargo clippy --no-default-features --features tracing_opentelemetry_0_32 --all-targets -- -D warnings` -> clean
- `cargo fmt --check` -> clean
- `cargo test --no-run --features gzip` (default feature = otel 0.32) -> compiles

Version bumped to 0.31.0 (minor, additive) so it can be released right after merge; downstream services can then pin 0.31.0 and move to otel 0.32 without a dual-version tree.
