### PR TITLE
Revert "Public docker image to Pull-Through cache"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 279066465364.dkr.ecr.eu-west-1.amazonaws.com/docker-hub/library/rust:1.96
+FROM rust:1.96
 
 WORKDIR /code
 


### PR DESCRIPTION
Reverts primait/bridge.rs#285

This is a public repo, it can't pull from there